### PR TITLE
feat: font chooser improvements + manifest fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1066,7 +1065,6 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1162,7 +1160,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1414,7 +1411,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1435,7 +1431,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1584,7 +1579,6 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1065,6 +1066,7 @@
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1160,6 +1162,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1411,6 +1414,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1431,6 +1435,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1579,6 +1584,7 @@
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,10 +20,7 @@
     "<all_urls>"
   ],
   "background": {
-    "service_worker": "background.js",
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js"
   },
   "browser_specific_settings": {
     "gecko": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, CSSProperties } from 'react'
 import { useBookmarks, useSettings, useLocalStorage } from './hooks/useLocalStorage'
 import { Bookmarks } from './components/Bookmarks'
 import { Clock } from './components/Clock'
@@ -53,6 +53,14 @@ function App() {
   const appRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    const root = document.documentElement
+    const fontValue = (settings.font || 'JetBrains Mono').includes(' ')
+      ? `'${settings.font || 'JetBrains Mono'}'`
+      : (settings.font || 'JetBrains Mono')
+    root.style.setProperty('--font-mono', fontValue)
+  }, [settings.font])
+
+  useEffect(() => {
     const stealFocus = () => {
       window.focus()
       if (document.activeElement === document.body) {
@@ -76,7 +84,7 @@ function App() {
         style={{
           outline: 'none',
           ...(bgImage ? { backgroundColor: 'transparent', background: 'none' } : {}),
-        }}
+        } as CSSProperties}
       >
         <SettingsPanel
           settings={settings}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, CSSProperties } from 'react'
+import { useEffect, useRef, type CSSProperties } from 'react'
 import { useBookmarks, useSettings, useLocalStorage } from './hooks/useLocalStorage'
 import { Bookmarks } from './components/Bookmarks'
 import { Clock } from './components/Clock'

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -32,13 +32,18 @@ const THEMES: ThemeInfo[] = [
 ]
 
 const FONTS = [
-  { id: 'jetbrains-mono', name: 'JetBrains Mono', family: 'JetBrains Mono' },
-  { id: 'fira-code', name: 'Fira Code', family: 'Fira Code' },
-  { id: 'cascadia-code', name: 'Cascadia Code', family: 'Cascadia Code' },
-  { id: 'ibm-plex-mono', name: 'IBM Plex Mono', family: 'IBM Plex Mono' },
-  { id: 'source-code-pro', name: 'Source Code Pro', family: 'Source Code Pro' },
-  { id: 'inconsolata', name: 'Inconsolata', family: 'Inconsolata' },
-  { id: 'hack', name: 'Hack', family: 'Hack' },
+  { id: 'jetbrains-mono',  name: 'JetBrains Mono',  family: 'JetBrains Mono' },
+  { id: 'geist-mono',      name: 'Geist Mono',       family: 'Geist Mono' },
+  { id: 'space-mono',      name: 'Space Mono',       family: 'Space Mono' },
+  { id: 'fira-code',       name: 'Fira Code',        family: 'Fira Code' },
+  { id: 'cascadia-code',   name: 'Cascadia Code',    family: 'Cascadia Code' },
+  { id: 'ibm-plex-mono',   name: 'IBM Plex Mono',    family: 'IBM Plex Mono' },
+  { id: 'intel-one-mono',  name: 'Intel One Mono',   family: 'Intel One Mono' },
+  { id: 'iosevka',         name: 'Iosevka',          family: 'Iosevka' },
+  { id: 'commit-mono',     name: 'Commit Mono',      family: 'Commit Mono' },
+  { id: 'source-code-pro', name: 'Source Code Pro',  family: 'Source Code Pro' },
+  { id: 'inconsolata',     name: 'Inconsolata',      family: 'Inconsolata' },
+  { id: 'hack',            name: 'Hack',             family: 'Hack' },
 ]
 
 interface SettingsPanelProps {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -31,6 +31,16 @@ const THEMES: ThemeInfo[] = [
   { id: 'midnight', name: 'Midnight', bgColor: '#020617', textColor: '#e2e8f0', accentColor: '#6366f1', category: 'special' },
 ]
 
+const FONTS = [
+  { id: 'jetbrains-mono', name: 'JetBrains Mono', family: 'JetBrains Mono' },
+  { id: 'fira-code', name: 'Fira Code', family: 'Fira Code' },
+  { id: 'cascadia-code', name: 'Cascadia Code', family: 'Cascadia Code' },
+  { id: 'ibm-plex-mono', name: 'IBM Plex Mono', family: 'IBM Plex Mono' },
+  { id: 'source-code-pro', name: 'Source Code Pro', family: 'Source Code Pro' },
+  { id: 'inconsolata', name: 'Inconsolata', family: 'Inconsolata' },
+  { id: 'hack', name: 'Hack', family: 'Hack' },
+]
+
 interface SettingsPanelProps {
   settings: SettingsType
   onSettingsChange: (settings: SettingsType) => void
@@ -278,6 +288,47 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                             <span className='theme-name'>{theme.name}</span>
                           </div>
                         ))}
+                      </div>
+                    </div>
+
+                    <div className='saas-section-group'>
+                      <label className='saas-section-label'>FONT FAMILY</label>
+                      <div className='saas-theme-grid'>
+                        {FONTS.map(font => {
+                          const isFontActive = localSettings.font === font.family;
+                          const currentTheme = THEMES.find(t => t.id === localSettings.theme) || THEMES[0];
+                          
+                          return (
+                            <div 
+                              key={font.id}
+                              className={`saas-theme-card ${isFontActive ? 'active' : ''}`}
+                              onClick={() => handleChange('font', font.family)}
+                            >
+                              <div 
+                                className='theme-preview'
+                                style={{ 
+                                  backgroundColor: currentTheme.bgColor,
+                                  borderColor: isFontActive ? currentTheme.accentColor : 'rgba(255,255,255,0.05)',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  fontFamily: `'${font.family}', monospace`,
+                                  fontSize: '20px',
+                                  color: currentTheme.textColor,
+                                  overflow: 'hidden'
+                                }}
+                              >
+                                <div style={{ opacity: 0.9 }}>Abc</div>
+                                {isFontActive && (
+                                  <div className='theme-check' style={{ backgroundColor: currentTheme.accentColor }}>
+                                    <Check size={12} strokeWidth={3} />
+                                  </div>
+                                )}
+                              </div>
+                              <span className='theme-name'>{font.name}</span>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -294,41 +294,43 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                     <div className='saas-section-group'>
                       <label className='saas-section-label'>FONT FAMILY</label>
                       <div className='saas-theme-grid'>
-                        {FONTS.map(font => {
-                          const isFontActive = localSettings.font === font.family;
+                        {(() => {
                           const currentTheme = THEMES.find(t => t.id === localSettings.theme) || THEMES[0];
-                          
-                          return (
-                            <div 
-                              key={font.id}
-                              className={`saas-theme-card ${isFontActive ? 'active' : ''}`}
-                              onClick={() => handleChange('font', font.family)}
-                            >
+                          return FONTS.map(font => {
+                            const isFontActive = localSettings.font === font.family;
+                            
+                            return (
                               <div 
-                                className='theme-preview'
-                                style={{ 
-                                  backgroundColor: currentTheme.bgColor,
-                                  borderColor: isFontActive ? currentTheme.accentColor : 'rgba(255,255,255,0.05)',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  fontFamily: `'${font.family}', monospace`,
-                                  fontSize: '20px',
-                                  color: currentTheme.textColor,
-                                  overflow: 'hidden'
-                                }}
+                                key={font.id}
+                                className={`saas-theme-card ${isFontActive ? 'active' : ''}`}
+                                onClick={() => handleChange('font', font.family)}
                               >
-                                <div style={{ opacity: 0.9 }}>Abc</div>
-                                {isFontActive && (
-                                  <div className='theme-check' style={{ backgroundColor: currentTheme.accentColor }}>
-                                    <Check size={12} strokeWidth={3} />
-                                  </div>
-                                )}
+                                <div 
+                                  className='theme-preview'
+                                  style={{ 
+                                    backgroundColor: currentTheme.bgColor,
+                                    borderColor: isFontActive ? currentTheme.accentColor : 'rgba(255,255,255,0.05)',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    fontFamily: `'${font.family}', monospace`,
+                                    fontSize: '20px',
+                                    color: currentTheme.textColor,
+                                    overflow: 'hidden'
+                                  }}
+                                >
+                                  <div style={{ opacity: 0.9 }}>Abc</div>
+                                  {isFontActive && (
+                                    <div className='theme-check' style={{ backgroundColor: currentTheme.accentColor }}>
+                                      <Check size={12} strokeWidth={3} />
+                                    </div>
+                                  )}
+                                </div>
+                                <span className='theme-name'>{font.name}</span>
                               </div>
-                              <span className='theme-name'>{font.name}</span>
-                            </div>
-                          );
-                        })}
+                            );
+                          });
+                        })()}
                       </div>
                     </div>
                   </div>

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -53,6 +53,7 @@ const DEFAULT_SETTINGS: Settings = {
   showDailyGoal: true,
   showGitHubStreak: false,
   githubUsername: '',
+  font: 'JetBrains Mono',
   asciiArt: `
   ⠀⠀⠀⠀⢠⡶⠚⢷⣤⡀⠀⠀⠀⠀⠀⣲⡶⠛⠻⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
 ⠀⠀⠀⢠⡿⠁⠀⠀⠙⣷⣄⠀⢀⣴⡟⠁⠀⠀⢷⢹⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀
@@ -80,7 +81,17 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: T 
   const [value, setValue] = useState<T>(() => {
     try {
       const stored = localStorage.getItem(key)
-      return stored ? JSON.parse(stored) : defaultValue
+      if (!stored) return defaultValue
+      
+      const parsed = JSON.parse(stored)
+      // If it's a plain object (not an array), merge with default value to ensure new properties exist
+      if (
+        typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) &&
+        typeof defaultValue === 'object' && defaultValue !== null && !Array.isArray(defaultValue)
+      ) {
+        return { ...defaultValue, ...parsed }
+      }
+      return parsed
     } catch {
       return defaultValue
     }
@@ -168,5 +179,13 @@ export function useTime() {
 
 export function useSettings() {
   const [settings, setSettings] = useLocalStorage<Settings>('startpage-settings', DEFAULT_SETTINGS)
+
+  // Sync font to dedicated key for easy access
+  useEffect(() => {
+    if (settings.font) {
+      localStorage.setItem('neko-font', settings.font)
+    }
+  }, [settings.font])
+
   return [settings, setSettings] as const
 }

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -177,14 +177,42 @@ export function useTime() {
   return time
 }
 
+const FONT_URLS: Record<string, string> = {
+  'JetBrains Mono': 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap',
+  'Geist Mono':     'https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;700&display=swap',
+  'Space Mono':     'https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&display=swap',
+  'Fira Code':      'https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap',
+  'Cascadia Code':  'https://fonts.googleapis.com/css2?family=Cascadia+Code:wght@400;700&display=swap',
+  'IBM Plex Mono':  'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap',
+  'Intel One Mono': 'https://fonts.googleapis.com/css2?family=Intel+One+Mono:wght@400;700&display=swap',
+  'Iosevka':        'https://fonts.googleapis.com/css2?family=Iosevka:wght@400;700&display=swap',
+  'Commit Mono':    'https://fonts.googleapis.com/css2?family=Commit+Mono:wght@400;700&display=swap',
+  'Source Code Pro':'https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;700&display=swap',
+  'Inconsolata':    'https://fonts.googleapis.com/css2?family=Inconsolata:wght@400;700&display=swap',
+  'Hack':           'https://cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css',
+}
+
+function loadFont(family: string) {
+  const url = FONT_URLS[family]
+  if (!url) return
+  const id = `font-${family.replace(/\s/g, '-')}`
+  if (document.getElementById(id)) return // already loaded
+  const link = document.createElement('link')
+  link.id = id
+  link.rel = 'stylesheet'
+  link.href = url
+  document.head.appendChild(link)
+}
+
 export function useSettings() {
   const [settings, setSettings] = useLocalStorage<Settings>('startpage-settings', DEFAULT_SETTINGS)
 
-  // Sync font to dedicated key for easy access
+  // Lazily load only the selected font — not all fonts upfront
   useEffect(() => {
-    if (settings.font) {
-      localStorage.setItem('neko-font', settings.font)
-    }
+    const font = settings.font || 'JetBrains Mono'
+    loadFont(font)
+    localStorage.setItem('neko-font', font)
+    document.documentElement.style.setProperty('--font-mono', `'${font}'`)
   }, [settings.font])
 
   return [settings, setSettings] as const

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Cascadia+Code:wght@400;700&family=Fira+Code:wght@400;700&family=IBM+Plex+Mono:wght@400;700&family=Inconsolata:wght@400;700&family=JetBrains+Mono:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap');
-@import url('https://cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css');
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap');
 
 /* Color Palette from reference */
 :root {
@@ -2285,8 +2284,8 @@ input[type="checkbox"]:checked::after {
   border-radius: 12px;
   width: 900px;
   max-width: 95vw;
-  height: 600px;
-  max-height: 90vh;
+  height: 80vh;
+  max-height: 800px;
   display: flex;
   overflow: hidden;
   box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.05);

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Cascadia+Code:wght@400;700&family=Fira+Code:wght@400;700&family=IBM+Plex+Mono:wght@400;700&family=Inconsolata:wght@400;700&family=JetBrains+Mono:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap');
+@import url('https://cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css');
+
 /* Color Palette from reference */
 :root {
+  --font-mono: 'JetBrains Mono';
   /* Dark colors */
   --onyx: #222526;
   --graphite: #353A3E;
@@ -34,7 +38,7 @@
 }
 
 body {
-  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  font-family: var(--font-mono), 'Fira Code', 'Consolas', monospace;
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
@@ -42,8 +46,13 @@ body {
   background: transparent;
 }
 
+input, button, textarea, select {
+  font-family: inherit;
+}
+
 /* Theme styles */
 .app {
+  font-family: var(--font-mono), 'Fira Code', 'Consolas', monospace;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -607,7 +616,7 @@ body {
 }
 
 .ascii-display {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 8px;
   line-height: 8px;
   white-space: pre;
@@ -1302,7 +1311,7 @@ body {
   border: 1px solid #2D3134;
   border-radius: 6px;
   color: #E0E0E0;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 9px;
   padding: 10px;
   resize: vertical;
@@ -1461,7 +1470,7 @@ body {
   background: #141617;
   border: 1px solid var(--border-color);
   color: var(--platinum);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 10px;
   padding: 10px;
   resize: vertical;
@@ -1715,7 +1724,7 @@ input[type="checkbox"]:checked::after {
   left: 0;
   right: 0;
   z-index: 100;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   background: var(--bg-secondary, rgba(0,0,0,0.3));
   border-top: 1px solid var(--border, rgba(255,255,255,0.1));
   padding: 8px 32px;
@@ -1875,7 +1884,7 @@ input[type="checkbox"]:checked::after {
 
 .focus-timer {
   font-size: 8rem;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-weight: 300;
   line-height: 1;
   color: #fff;
@@ -2723,7 +2732,7 @@ input[type="checkbox"]:checked::after {
   align-items: center;
   gap: 8px;
   cursor: text;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 14px;
   min-height: 24px;
   padding: 4px 0;
@@ -2825,7 +2834,7 @@ input[type="checkbox"]:checked::after {
 .scratchpad-title {
   font-size: 13px;
   color: var(--accent);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   letter-spacing: 0.5px;
 }
 
@@ -2836,7 +2845,7 @@ input[type="checkbox"]:checked::after {
   font-size: 11px;
   color: var(--text-secondary);
   opacity: 0.6;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .scratchpad-close {
@@ -2859,7 +2868,7 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 13px;
   line-height: 1.7;
   padding: 20px;
@@ -3029,7 +3038,7 @@ input[type="checkbox"]:checked::after {
   background: none;
   border: none;
   color: var(--text-secondary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 11px;
   padding: 4px 10px;
   cursor: pointer;
@@ -3096,7 +3105,7 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 13px;
   outline: none;
   padding: 2px 0;
@@ -3120,7 +3129,7 @@ input[type="checkbox"]:checked::after {
   background: none;
   border: none;
   color: var(--text-secondary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 11px;
   padding: 4px 4px;
   cursor: pointer;
@@ -3179,7 +3188,7 @@ input[type="checkbox"]:checked::after {
   box-shadow: 0 8px 32px rgba(0,0,0,0.35);
   animation: slideIn 0.15s cubic-bezier(0.16, 1, 0.3, 1);
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .cp-input-row {
@@ -3197,7 +3206,7 @@ input[type="checkbox"]:checked::after {
   background: transparent;
   border: none;
   color: var(--text-primary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 14px;
   outline: none;
   caret-color: var(--accent);
@@ -3212,7 +3221,7 @@ input[type="checkbox"]:checked::after {
   border: 1px solid var(--border);
   padding: 2px 6px;
   border-radius: 3px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .cp-results { max-height: 360px; overflow-y: auto; }
@@ -3270,7 +3279,7 @@ input[type="checkbox"]:checked::after {
   color: var(--text-secondary);
   opacity: 0.4;
   text-align: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 /* ==================== WORK TIMER ==================== */
@@ -3342,7 +3351,7 @@ input[type="checkbox"]:checked::after {
 .sh-title {
   font-size: 13px;
   color: var(--accent);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .sh-close {
@@ -3367,7 +3376,7 @@ input[type="checkbox"]:checked::after {
 }
 
 .sh-kbd {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 11px;
   color: var(--accent);
   background: rgba(255,255,255,0.05);
@@ -3393,7 +3402,7 @@ input[type="checkbox"]:checked::after {
   color: var(--text-secondary);
   opacity: 0.4;
   text-align: center;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .sh-footer .sh-kbd {
@@ -3419,7 +3428,7 @@ input[type="checkbox"]:checked::after {
   background: rgba(255,255,255,0.03);
   border-radius: 4px;
   font-size: 12px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 .alias-key {
@@ -3473,7 +3482,7 @@ input[type="checkbox"]:checked::after {
 .sp-day-btn {
   background: none;
   border: none;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 11px;
   color: var(--text-secondary);
   opacity: 0.45;
@@ -3498,7 +3507,7 @@ input[type="checkbox"]:checked::after {
   opacity: 0.4;
   text-transform: uppercase;
   letter-spacing: 1px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
 }
 
 @keyframes slideIn {
@@ -3536,7 +3545,7 @@ input[type="checkbox"]:checked::after {
 .cp-trigger-text {
   flex: 1;
   font-size: 13px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   color: var(--text-secondary);
   opacity: 0.35;
   overflow: hidden;
@@ -3552,7 +3561,7 @@ input[type="checkbox"]:checked::after {
 }
 
 .cp-trigger-hint kbd {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 10px;
   color: var(--text-secondary);
   opacity: 0.4;
@@ -3580,7 +3589,7 @@ input[type="checkbox"]:checked::after {
   border: 1px solid transparent;
   border-radius: 3px;
   color: var(--text-secondary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 10px;
   padding: 2px 5px;
   cursor: pointer;
@@ -3608,7 +3617,7 @@ input[type="checkbox"]:checked::after {
   gap: 20px;
   padding: 10px 16px;
   font-size: 11px;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   color: var(--text-secondary);
   opacity: 0.4;
   border-top: 1px solid var(--border);
@@ -3636,7 +3645,7 @@ input[type="checkbox"]:checked::after {
 .cp-clear-btn {
   background: none;
   border: none;
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono), monospace;
   font-size: 11px;
   color: var(--text-secondary);
   opacity: 0.4;

--- a/src/index.css
+++ b/src/index.css
@@ -616,7 +616,7 @@ input, button, textarea, select {
 }
 
 .ascii-display {
-  font-family: var(--font-mono), monospace;
+  font-family: 'JetBrains Mono', monospace;
   font-size: 8px;
   line-height: 8px;
   white-space: pre;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,4 +50,6 @@ export interface Settings {
   showDailyGoal: boolean
   showGitHubStreak: boolean
   githubUsername: string
+  // Font
+  font: string
 }


### PR DESCRIPTION
Hey @ramysami, great work on the font chooser — took it from here and made a few changes on top.

**Lazy font loading** — the original loaded all 6 fonts upfront via two `@import` statements in CSS, meaning 7 network requests on every new tab open regardless of which font the user picked. Replaced with a dynamic `loadFont()` function that injects a `<link>` tag only for the active font, once per session. Default tab now makes 1 font request instead of 7.

**Added 5 more fonts** — Geist Mono (Vercel), Space Mono, Intel One Mono, Iosevka, Commit Mono. All on Google Fonts, all fit the terminal aesthetic. 12 fonts total.

**Settings modal height** — bumped from fixed `600px` to `80vh / max 800px` so the FONT FAMILY section is actually visible without being cut off at the bottom of the Appearance tab.

**Manifest fix** — removed `background.scripts` which is MV2-only and was causing a browser warning. MV3 only needs `service_worker`.