### PR TITLE
fix: Settings panel low width improvements

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -138,6 +138,9 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
       {isOpen && (
         <div className='settings-overlay' onClick={() => setIsOpen(false)}>
           <div className='saas-modal' onClick={e => e.stopPropagation()}>
+            <button className='saas-close-btn top-right' onClick={() => setIsOpen(false)}>
+              <X size={18} />
+            </button>
             {/* Sidebar Navigation */}
             <div className='saas-sidebar'>
               <div className='saas-sidebar-header'>
@@ -188,9 +191,6 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                   {activeTab === 'widgets' && 'Widgets & Background'}
                   {activeTab === 'aliases' && 'URL Aliases'}
                 </h3>
-                <button className='saas-close-btn' onClick={() => setIsOpen(false)}>
-                  <X size={18} />
-                </button>
               </div>
 
               <div className='saas-content-scroll' key={activeTab}>

--- a/src/index.css
+++ b/src/index.css
@@ -2367,12 +2367,19 @@ input[type="checkbox"]:checked::after {
   border: none;
   color: #888;
   cursor: pointer;
-  padding: 4px;
+  padding: 8px;
   border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
+}
+
+.saas-close-btn.top-right {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1001;
 }
 
 .saas-close-btn:hover {
@@ -2705,6 +2712,7 @@ input[type="checkbox"]:checked::after {
     flex-direction: row;
     flex-wrap: wrap;
     gap: 8px;
+    padding-right: 40px; /* Space for the close button */
   }
   .saas-nav-item {
     width: auto;


### PR DESCRIPTION
Fixes #11 

Also improves the position of the close button to the top of the panel.

Also make the links section horizontally scrollable when there is not enough space.