### PR TITLE
feat(command-palette): add Ctrl+N/Ctrl+P navigation

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -394,8 +394,8 @@ export function CommandPalette() {
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') { e.preventDefault(); setSelected(s => Math.min(s + 1, results.length - 1)) }
-    if (e.key === 'ArrowUp')   { e.preventDefault(); setSelected(s => Math.max(s - 1, 0)) }
+    if (e.key === 'ArrowDown' || (e.ctrlKey && e.code === 'KeyN')) { e.preventDefault(); setSelected(s => Math.min(s + 1, results.length - 1)) }
+    if (e.key === 'ArrowUp'   || (e.ctrlKey && e.code === 'KeyP')) { e.preventDefault(); setSelected(s => Math.max(s - 1, 0)) }
     // Tab autocompletes command suggestions
     if (e.key === 'Tab' && results[selected]?.type === 'command' && !results[selected]?.action) {
       e.preventDefault()


### PR DESCRIPTION
## Summary
- Add Ctrl+N (next) and Ctrl+P (previous) as alternative keybindings for navigating command palette results alongside arrow keys
- Uses `e.code` instead of `e.key` for reliable detection when Ctrl modifier is held

## Test plan
- [ ] Open command palette (Ctrl+K), type a query, verify Ctrl+N moves selection down
- [ ] Verify Ctrl+P moves selection up
- [ ] Verify arrow keys still work as before