### PR TITLE
fix: address review feedback on error handling, release safety, and startup reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,25 +58,37 @@ jobs:
             echo "RELEASE_TAG=$GITHUB_REF_NAME" >> $GITHUB_ENV
           fi
 
-      - name: Auto-Increment, Commit, and Move Tag
+      - name: Auto-Increment, Commit, and Create Tag
+        env:
+          NEW_VERSION: ${{ env.NEW_VERSION }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'main' }}
         run: |
-          jq --arg ver "${{ env.NEW_VERSION }}" '.version = $ver' public/manifest.json > tmp.json && mv tmp.json public/manifest.json
-          
+          jq --arg ver "$NEW_VERSION" '.version = $ver' public/manifest.json > tmp.json && mv tmp.json public/manifest.json
+
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           git add public/manifest.json
-          
+
           if git diff --staged --quiet; then
             echo "Version in manifest is already up to date. Skipping commit."
           else
-            git commit -m "chore: bump version to ${{ env.NEW_VERSION }} [skip ci]"
+            git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
             # Dynamically push back to the branch that triggered the workflow
-            git push origin ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'main' }}
+            git push origin "$TARGET_REF"
           fi
-          
-          git tag -f ${{ env.RELEASE_TAG }}
-          git push origin ${{ env.RELEASE_TAG }} --force
+
+          if git rev-parse "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag $RELEASE_TAG already exists locally. Refusing to move it."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag $RELEASE_TAG already exists on origin. Refusing to move it."
+            exit 1
+          fi
+          git tag "$RELEASE_TAG"
+          git push origin "$RELEASE_TAG"
 
       - name: Set up Node.js
         uses: actions/setup-node@v5

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules/
 .codex
 .claude/
 graphify-out/
+docs/

--- a/public/background.js
+++ b/public/background.js
@@ -34,7 +34,9 @@ chrome.storage.local.onChanged.addListener((changes) => {
   if (changes.focusBlocking) {
     const { isActive, blockedDomains, sessionId } = changes.focusBlocking.newValue || { isActive: false, blockedDomains: [], sessionId: null }
     activeFocusBlocking = { isActive, blockedDomains, sessionId: sessionId ?? null }
-    updateBlockingRules(isActive, blockedDomains)
+    void updateBlockingRules(isActive, blockedDomains).catch(error => {
+      console.error('Failed to sync focus blocking rules from storage:', error)
+    })
   }
 })
 
@@ -61,8 +63,13 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     activeFocusBlocking = nextState
 
     void (async () => {
-      await updateBlockingRules(nextState.isActive, nextState.blockedDomains)
-      sendResponse({ ok: true })
+      try {
+        await updateBlockingRules(nextState.isActive, nextState.blockedDomains)
+        sendResponse({ ok: true })
+      } catch (error) {
+        console.error('Failed to sync focus blocking rules:', error)
+        sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) })
+      }
     })()
 
     return true
@@ -204,15 +211,11 @@ async function updateBlockingRules(isActive, blockedDomains) {
     }
   }))
 
-  try {
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      addRules: rules,
-      removeRuleIds: []
-    })
-    console.log('Focus mode blocking enabled for:', normalizedDomains)
-  } catch (error) {
-    console.error('Failed to update blocking rules:', error)
-  }
+  await chrome.declarativeNetRequest.updateDynamicRules({
+    addRules: rules,
+    removeRuleIds: []
+  })
+  console.log('Focus mode blocking enabled for:', normalizedDomains)
 }
 
 async function clearAllBlockingRules() {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Neko Tab",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "key": "__GOOGLE_EXTENSION_KEY__",
   "description": "Custom Terminal-style New Tab Page",
   "content_security_policy": {

--- a/src/hooks/useStartupSites.ts
+++ b/src/hooks/useStartupSites.ts
@@ -26,49 +26,60 @@ export function useStartupSites() {
 
   const openStartupSites = useCallback(async () => {
     if (sites.length === 0) return
-    markShown()
 
-    const existingTabs = await chrome.tabs.query({ currentWindow: true })
+    try {
+      const existingTabs = await chrome.tabs.query({ currentWindow: true })
 
-    for (const site of sites) {
-      const siteHostname = new URL(site.url).hostname
-      const alreadyOpen = existingTabs.find(t => {
-        try {
-          return new URL(t.url ?? '').hostname === siteHostname
-        } catch {
-          return false
+      for (const site of sites) {
+        const siteHostname = new URL(site.url).hostname
+        const alreadyOpen = existingTabs.find(t => {
+          try {
+            return new URL(t.url ?? '').hostname === siteHostname
+          } catch {
+            return false
+          }
+        })
+        if (alreadyOpen?.id != null) {
+          await chrome.tabs.update(alreadyOpen.id, { active: true })
+        } else {
+          await chrome.tabs.create({ url: site.url, active: false })
         }
-      })
-      if (alreadyOpen?.id != null) {
-        await chrome.tabs.update(alreadyOpen.id, { active: true })
-      } else {
-        await chrome.tabs.create({ url: site.url, active: false })
       }
-    }
 
-    // Send toast notification to App component
-    chrome.runtime?.sendMessage?.({
-      type: 'neko-startup-sites-opened',
-      count: sites.length
-    }).catch(() => {})
+      markShown()
+
+      // Send toast notification to App component
+      chrome.runtime?.sendMessage?.({
+        type: 'neko-startup-sites-opened',
+        count: sites.length
+      }).catch(() => {})
+    } catch (error) {
+      console.error('Failed to open startup sites:', error)
+    }
   }, [sites, markShown])
 
   // Mirror to chrome.storage.local so the background service worker can read it
   useEffect(() => {
     if (typeof chrome !== 'undefined' && chrome.storage?.local) {
-      void chrome.storage.local.set({ neko_startup_sites: sites })
+      void chrome.storage.local.set({ neko_startup_sites: sites }).catch(error => {
+        console.error('Failed to mirror startup sites to chrome.storage.local:', error)
+      })
     }
   }, [sites])
 
   useEffect(() => {
     if (typeof chrome !== 'undefined' && chrome.storage?.local) {
-      void chrome.storage.local.set({ neko_startup_enabled: enabled })
+      void chrome.storage.local.set({ neko_startup_enabled: enabled }).catch(error => {
+        console.error('Failed to mirror startup sites enabled state to chrome.storage.local:', error)
+      })
     }
   }, [enabled])
 
   useEffect(() => {
     if (typeof chrome !== 'undefined' && chrome.storage?.local) {
-      void chrome.storage.local.set({ neko_startup_shown: shownDate })
+      void chrome.storage.local.set({ neko_startup_shown: shownDate }).catch(error => {
+        console.error('Failed to mirror startup sites shown date to chrome.storage.local:', error)
+      })
     }
   }, [shownDate])
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,8 @@ export default defineConfig(({ mode }) => {
             writeFileSync(manifestPath, manifest)
             console.log('manifest.json injected')
           } catch (error) {
-            console.warn('Could not inject manifest values:', error)
+            console.error('Failed to inject manifest values:', error)
+            throw error
           }
         }
       }


### PR DESCRIPTION
## Summary
This PR bundles review-driven fixes for reliability and safety across the extension and CI pipeline.

### What changed
- **`.github/workflows/release.yml`**
  - Replaced inline `${{ }}` interpolation inside `run` blocks with env vars to avoid script injection and shell quoting issues.
  - Added guards that refuse to create or move a release tag if it already exists locally or on the remote, preventing accidental overwrites.
  - Removed `--force` from tag push.

- **`public/background.js`**
  - Centralized error handling for focus-blocking declarativeNetRequest updates.
  - Async failures are now caught and logged at the listener/message level instead of being swallowed inside `updateBlockingRules`.
  - `sendResponse` now returns `{ ok: false, error: ... }` on failures.

- **`src/hooks/useStartupSites.ts`**
  - Moved `markShown()` to **after** all tabs are successfully opened/activated so a failure doesn’t incorrectly mark the session as shown.
  - Wrapped the entire `openStartupSites` flow in a `try/catch`.
  - Added explicit `.catch()` handlers on `chrome.storage.local.set` calls with descriptive error messages.

- **`vite.config.ts`**
  - Manifest-injection failures now `console.error` instead of `console.warn` and **throw** to fail the build, surfacing misconfiguration immediately.

- **`public/manifest.json`**
  - Bumped version `1.1.0` → `1.2.0`.

- **`.gitignore`**
  - Added `docs/` directory.

### Side effects / things to watch out for
- The release workflow will now **fail** if a tag already exists rather than silently moving it. This is intentional and safer.
- Build will fail if `GOOGLE_CLIENT_ID` or `GOOGLE_EXTENSION_KEY` are missing or malformed, instead of producing a broken manifest silently.