### PR TITLE
feat: AI command interpreter with persistent memory system

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ Press `Ctrl+K` or `/` to open the unified command palette. It replaces the tradi
 - **Engine switcher** — switch between Google, DuckDuckGo, GitHub, and YouTube inside the palette
 - **Fuzzy search** — matches bookmarks by title, URL, or category
 
+### AI Command Interpreter
+
+Type `!` in the command palette to trigger AI mode. Powered by your choice of provider (OpenAI, Anthropic, Gemini, or custom API).
+
+- **Natural language navigation** — `! open slack and discord` opens both in new tabs
+- **Smart URL resolution** — prefers your most-visited URLs from browser history
+- **AI Memory** — automatically learns which URLs you use for each service; suggests new mappings as you use the palette
+- **View and manage** learned mappings in **Settings → AI → AI Memory**
+
+### AI Memory
+
+The AI learns from your browsing patterns over time:
+
+- **History scan** — on first use, scans your Chrome history to build a map of frequently visited destinations
+- **Auto-learning** — every time the AI successfully opens a service, it remembers the exact URL you use
+- **AI suggestions** — the AI can propose new memory mappings when it opens unfamiliar services
+- **Settings UI** — view, edit, search, and delete learned memories in **Settings → AI**
+
 ### Theming
 
 20+ professionally crafted themes across three categories:
@@ -170,6 +188,7 @@ Open the gear icon (top-right) to access:
 - **Widgets** — background image with dim/blur controls, daily goal, GitHub streak (set username)
 - **Aliases** — define short URL aliases for the command palette
 - **Integrations** — connect Google Calendar to show upcoming events on the home page
+- **AI** — configure AI providers (OpenAI, Anthropic, Gemini), manage learned URL memories
 - **Focus Mode** — configure default duration and blocked sites
 - **Advanced** — reset all user data and wipe stored settings cleanly
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -6,6 +6,9 @@ import { Search, Earth } from 'lucide-react'
 import { openChromeNewTab } from './ChromeTabButton'
 import { recordTabUsage } from '../utils/tabUsage'
 import { useOpenTabs } from '../hooks/useOpenTabs'
+import { useAIProviders } from '../hooks/useAIProviders'
+import { useAIMemory } from '../hooks/useAIMemory'
+import { executeActions, buildContext, fetchFrequentDestinations } from '../utils/ai-command-parser'
 
 interface Result {
   id: string
@@ -14,7 +17,7 @@ interface Result {
   url?: string
   action?: () => void
   icon: any
-  type: 'alias' | 'bookmark' | 'search' | 'url' | 'recent' | 'command' | 'history' | 'calc' | 'tab'
+  type: 'alias' | 'bookmark' | 'search' | 'url' | 'recent' | 'command' | 'history' | 'calc' | 'tab' | 'ai'
 }
 
 interface RecentItem {
@@ -223,9 +226,28 @@ export function CommandPalette() {
   const [, setDailyGoal] = useLocalStorage<{ text: string; date: string } | null>('neko-daily-goal', null)
   const [, setScratchpad] = useLocalStorage<string>('neko-scratchpad', '')
   const { tabs } = useOpenTabs()
+  const { activeProvider, executeCommand, loadProviders } = useAIProviders()
+  const { memories, saveMemory } = useAIMemory()
+  const [aiLoading, setAiLoading] = useState(false)
+  const [aiError, setAiError] = useState<string | null>(null)
+  const fetchedRef = useRef(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const resultsRef = useRef<HTMLDivElement>(null)
   const toastTimer = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    if (isOpen && !fetchedRef.current) {
+      fetchedRef.current = true
+      fetchFrequentDestinations().then(historyMemories => {
+        for (const m of historyMemories) {
+          const existing = memories.find(x => x.keyword === m.keyword)
+          if (!existing) {
+            saveMemory(m.keyword, m.url, 'history')
+          }
+        }
+      })
+    }
+  }, [isOpen])
 
   const showToast = useCallback((msg: string) => {
     setToast(msg)
@@ -242,7 +264,7 @@ export function CommandPalette() {
 
   // Search browser history when query changes
   useEffect(() => {
-    if (!query.trim() || query.startsWith('/') || query.startsWith('=')) {
+    if (!query.trim() || query.startsWith('/') || query.startsWith('=') || query.startsWith('!')) {
       setHistoryResults([])
       return
     }
@@ -295,6 +317,10 @@ export function CommandPalette() {
   useEffect(() => {
     if (isOpen) setTimeout(() => inputRef.current?.focus(), 30)
   }, [isOpen])
+
+  useEffect(() => {
+    loadProviders()
+  }, [loadProviders])
 
   const results = useMemo<Result[]>(() => {
     const out: Result[] = []
@@ -493,6 +519,76 @@ export function CommandPalette() {
       return out
     }
 
+    // ── AI Command — triggered by "!" prefix ──
+    if (query.startsWith('!')) {
+      if (activeProvider) {
+        const aiQuery = query.slice(1).trim()
+        if (aiQuery) {
+          out.push({
+            id: 'ai-command',
+            label: aiQuery,
+            sub: aiLoading ? 'Processing...' : 'Ask AI',
+            icon: aiLoading ? <span className="cp-dots"><span /><span /><span /></span> : '✦',
+            type: 'ai' as const,
+            action: aiLoading ? undefined : async () => {
+              setAiLoading(true)
+              setAiError(null)
+
+              try {
+                const context = buildContext(
+                  aliases,
+                  categories,
+                  recent.slice(0, 10).map(r => ({ title: r.label, url: r.url })),
+                  historyResults.slice(0, 10).map(h => ({ title: h.label, url: h.url })),
+                  memories
+                )
+
+                const actions = await executeCommand(aiQuery, context)
+                const rememberActions = actions.filter(a => a.type === 'remember')
+                const execActions = actions.filter(a => a.type !== 'remember')
+
+                if (execActions.length > 0) {
+                  await executeActions(execActions)
+                }
+
+                for (const ra of rememberActions) {
+                  if (ra.url) {
+                    await saveMemory(ra.value, ra.url, 'ai')
+                    showToast(`Learned: "${ra.value}" → ${ra.url}`)
+                  }
+                }
+
+                if (execActions.length === 0 && rememberActions.length === 0) {
+                  setAiError('No actions returned from AI')
+                  return
+                }
+
+                if (execActions.length > 0) {
+                  showToast(`Executed ${execActions.length} action${execActions.length > 1 ? 's' : ''}`)
+                }
+              } catch (err) {
+                setAiError(err instanceof Error ? err.message : 'AI command failed')
+                return
+              } finally {
+                setAiLoading(false)
+              }
+              setIsOpen(false)
+              setQuery('')
+            },
+          })
+        }
+      } else {
+        out.push({
+          id: 'ai-no-provider',
+          label: 'No AI provider configured',
+          sub: 'Add an API key in Settings > AI',
+          icon: '⚠️',
+          type: 'command' as const,
+        })
+      }
+      return out
+    }
+
     // ── Normal search (existing logic) ──
 
     // When empty — show recent first
@@ -584,7 +680,7 @@ export function CommandPalette() {
     }
 
     return out
-  }, [query, categories, aliases, engine, settings.theme, settings.font, settings.clockFormat, recent, historyResults, showToast, setSettings, setRecent, setDailyGoal, setScratchpad, tabs])
+  }, [query, categories, aliases, engine, settings.theme, settings.font, settings.clockFormat, recent, historyResults, showToast, setSettings, setRecent, setDailyGoal, setScratchpad, tabs, activeProvider, aiLoading, executeCommand])
 
   useEffect(() => { setSelected(0) }, [query])
 
@@ -615,6 +711,10 @@ export function CommandPalette() {
       return
     }
     if (r.action) {
+      if (r.type === 'ai') {
+        r.action()
+        return
+      }
       r.action()
     } else if (r.url) {
       void recordTabUsage()
@@ -715,12 +815,17 @@ export function CommandPalette() {
               </div>
             )}
 
+            {aiError && (
+              <div className="cp-ai-error">⚠️ {aiError}</div>
+            )}
+
             {!query && (
               <div className="cp-hint-row">
                 <span>↑↓ navigate</span>
                 <span>↵ open</span>
                 <span>/commands</span>
                 <span>&gt; tabs</span>
+                {activeProvider && <span>! AI</span>}
                 {recent.length > 0
                   ? <button className="cp-clear-btn" onClick={e => { e.stopPropagation(); setRecent([]) }}>clear history</button>
                   : <span>esc close</span>

--- a/src/components/Settings/AIMemory.tsx
+++ b/src/components/Settings/AIMemory.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+import { useAIMemory } from '../../hooks/useAIMemory'
+import type { AIMemory } from '../../types'
+import { Trash2, Search, Book } from 'lucide-react'
+
+export function AIMemorySettings() {
+  const { memories, deleteMemory, updateMemory, clearAll } = useAIMemory()
+  const [filter, setFilter] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+  const [editKeyword, setEditKeyword] = useState('')
+  const [editUrl, setEditUrl] = useState('')
+
+  const filtered = filter
+    ? memories.filter(m =>
+        m.keyword.toLowerCase().includes(filter.toLowerCase()) ||
+        m.url.toLowerCase().includes(filter.toLowerCase())
+      )
+    : memories
+
+  const startEdit = (m: AIMemory) => {
+    setEditing(m.keyword)
+    setEditKeyword(m.keyword)
+    setEditUrl(m.url)
+  }
+
+  const saveEdit = async () => {
+    if (!editing || !editKeyword.trim() || !editUrl.trim()) return
+    await updateMemory(editing, { keyword: editKeyword.trim(), url: editUrl.trim() })
+    setEditing(null)
+  }
+
+  const sourceLabel = (s: AIMemory['source']) => {
+    switch (s) {
+      case 'history': return 'History'
+      case 'ai': return 'AI'
+      case 'manual': return 'Manual'
+    }
+  }
+
+  return (
+    <div className="saas-card">
+      <div className="saas-flex-row" style={{ justifyContent: 'space-between', marginBottom: 16 }}>
+        <label className="saas-label" style={{ margin: 0 }}>
+          <Book size={16} style={{ marginRight: 8 }} />
+          AI Memory ({memories.length})
+        </label>
+        {memories.length > 0 && (
+          <button className="saas-btn-secondary" onClick={clearAll} style={{ fontSize: 12, color: '#ef4444' }}>
+            Clear All
+          </button>
+        )}
+      </div>
+
+      <div className="saas-input-wrapper" style={{ position: 'relative', marginBottom: 12 }}>
+        <Search size={14} style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', opacity: 0.4 }} />
+        <input
+          className="saas-input"
+          style={{ paddingLeft: 28 }}
+          placeholder="Search memories..."
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+        />
+      </div>
+
+      {memories.length === 0 ? (
+        <p className="saas-hint">
+          No memories yet. Use <code style={{ background: 'rgba(255,255,255,0.1)', padding: '2px 6px', borderRadius: 4 }}>!</code> commands in the palette and the AI will learn your frequently visited URLs over time.
+        </p>
+      ) : filtered.length === 0 ? (
+        <p className="saas-hint">No memories match your search.</p>
+      ) : (
+        <div className="provider-list">
+          <div style={{ display: 'flex', fontSize: 11, opacity: 0.5, padding: '4px 0', borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+            <span style={{ width: '30%' }}>Keyword</span>
+            <span style={{ flex: 1 }}>URL</span>
+            <span style={{ width: 60, textAlign: 'center' }}>Used</span>
+            <span style={{ width: 60, textAlign: 'center' }}>Source</span>
+            <span style={{ width: 40 }} />
+          </div>
+          {filtered.map(m => (
+            <div key={m.keyword} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 0', borderBottom: '1px solid rgba(255,255,255,0.06)' }}>
+              {editing === m.keyword ? (
+                <>
+                  <input
+                    className="saas-input"
+                    style={{ width: '28%', fontSize: 12, padding: '3px 6px' }}
+                    value={editKeyword}
+                    onChange={e => setEditKeyword(e.target.value)}
+                  />
+                  <input
+                    className="saas-input"
+                    style={{ flex: 1, fontSize: 12, padding: '3px 6px' }}
+                    value={editUrl}
+                    onChange={e => setEditUrl(e.target.value)}
+                  />
+                  <button className="saas-btn-primary" style={{ fontSize: 11, padding: '3px 8px' }} onClick={saveEdit}>Save</button>
+                  <button className="saas-btn-secondary" style={{ fontSize: 11, padding: '3px 8px' }} onClick={() => setEditing(null)}>Cancel</button>
+                </>
+              ) : (
+                <>
+                  <span
+                    style={{ width: '30%', fontWeight: 500, fontSize: 13, cursor: 'pointer', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    onClick={() => startEdit(m)}
+                    title={m.keyword}
+                  >
+                    {m.keyword}
+                  </span>
+                  <span
+                    style={{ flex: 1, fontSize: 12, opacity: 0.7, cursor: 'pointer', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                    onClick={() => startEdit(m)}
+                    title={m.url}
+                  >
+                    {m.url}
+                  </span>
+                  <span style={{ width: 60, textAlign: 'center', fontSize: 11, opacity: 0.5 }}>{m.usageCount}</span>
+                  <span style={{ width: 60, textAlign: 'center', fontSize: 11, opacity: 0.5 }}>{sourceLabel(m.source)}</span>
+                  <button className="saas-btn-icon" onClick={() => deleteMemory(m.keyword)}>
+                    <Trash2 size={12} />
+                  </button>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Settings/AIProviders.tsx
+++ b/src/components/Settings/AIProviders.tsx
@@ -1,0 +1,269 @@
+import { useState, useEffect } from 'react'
+import { useAIProviders } from '../../hooks/useAIProviders'
+import type { AIProvider, AIProviderConfig } from '../../types'
+import { Key, Trash2, Plus, Check, AlertCircle } from 'lucide-react'
+
+interface AIProvidersProps {
+  _settings: any
+  _onSettingsChange: any
+}
+
+function maskKey(key: string): string {
+  if (key.length <= 8) return key.slice(0, 2) + '****'
+  return key.slice(0, 4) + '****' + key.slice(-4)
+}
+
+export function AIProviders(_props: AIProvidersProps) {
+  const { providers, activeProvider, saveProvider, removeProvider, setActive, loadProviders, providerDefaults } = useAIProviders()
+
+  useEffect(() => {
+    loadProviders()
+  }, [loadProviders])
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [newProvider, setNewProvider] = useState<AIProvider>('openai')
+  const [apiKey, setApiKey] = useState('')
+  const [customBaseUrl, setCustomBaseUrl] = useState('')
+  const [customModel, setCustomModel] = useState('')
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
+  const [editingKey, setEditingKey] = useState<AIProvider | null>(null)
+  const [editKeyValue, setEditKeyValue] = useState('')
+
+  const handleAddProvider = async () => {
+    if (!apiKey.trim()) return
+
+    const providerConfig: AIProviderConfig = {
+      provider: newProvider,
+      name: providerDefaults[newProvider].name,
+      apiKey: apiKey.trim(),
+      baseUrl: newProvider === 'custom' ? customBaseUrl : undefined,
+      model: newProvider === 'custom' ? customModel : providerDefaults[newProvider].model,
+    }
+
+    await saveProvider(providerConfig)
+    setApiKey('')
+    setCustomBaseUrl('')
+    setCustomModel('')
+    setShowAddForm(false)
+
+    if (!activeProvider) {
+      await setActive(newProvider)
+    }
+  }
+
+  const handleUpdateKey = async (provider: AIProvider) => {
+    if (!editKeyValue.trim()) return
+    const existing = providers.find(p => p.provider === provider)
+    if (!existing) return
+
+    await saveProvider({ ...existing, apiKey: editKeyValue.trim() })
+    setEditingKey(null)
+    setEditKeyValue('')
+  }
+
+  const handleTestProvider = async () => {
+    setTesting(true)
+    setTestResult(null)
+
+    try {
+      const provider = providers.find(p => p.provider === activeProvider)
+      if (!provider) {
+        throw new Error('No provider configured')
+      }
+
+      const providerType = provider.provider
+      const baseUrl = provider.baseUrl || providerDefaults[providerType].baseUrl
+      if (!baseUrl) {
+        throw new Error('Base URL not configured')
+      }
+
+      let response: Response
+
+      if (providerType === 'openai' || providerType === 'custom') {
+        response = await fetch(`${baseUrl}/models`, {
+          headers: { 'Authorization': `Bearer ${provider.apiKey}` },
+        })
+      } else if (providerType === 'anthropic') {
+        response = await fetch(`${baseUrl}/messages`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': provider.apiKey,
+            'anthropic-version': '2023-06-01',
+          },
+          body: JSON.stringify({ model: provider.model || 'claude-3-haiku-20240307', max_tokens: 1, messages: [{ role: 'user', content: 'hi' }] }),
+        })
+      } else if (providerType === 'gemini') {
+        response = await fetch(`${baseUrl}/models?key=${provider.apiKey}`, {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      } else {
+        throw new Error(`Unknown provider: ${providerType}`)
+      }
+
+      if (response.ok) {
+        setTestResult({ success: true, message: 'Connection successful!' })
+      } else {
+        const errorText = await response.text().catch(() => '')
+        setTestResult({ success: false, message: `API returned ${response.status}${errorText ? ' — ' + errorText.slice(0, 100) : ''}` })
+      }
+    } catch (err) {
+      setTestResult({ success: false, message: err instanceof Error ? err.message : 'Connection failed' })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  return (
+    <div className="saas-section">
+      <div className="saas-card">
+        <div className="saas-flex-row" style={{ justifyContent: 'space-between', marginBottom: 16 }}>
+          <label className="saas-label" style={{ margin: 0 }}>
+            <Key size={16} style={{ marginRight: 8 }} />
+            AI Providers
+          </label>
+          <button className="saas-btn-primary" onClick={() => setShowAddForm(!showAddForm)}>
+            <Plus size={14} /> Add Provider
+          </button>
+        </div>
+
+        {showAddForm && (
+          <div className="ai-add-form" style={{ marginBottom: 16, padding: 12, background: 'rgba(255,255,255,0.05)', borderRadius: 8 }}>
+            <div className="saas-segmented-control" style={{ marginBottom: 8 }}>
+              {(['openai', 'anthropic', 'gemini', 'custom'] as AIProvider[]).map(p => (
+                <button
+                  key={p}
+                  className={`saas-segment ${newProvider === p ? 'active' : ''}`}
+                  onClick={() => setNewProvider(p)}
+                >
+                  {p === 'openai' ? 'OpenAI' : p === 'anthropic' ? 'Claude' : p === 'gemini' ? 'Gemini' : 'Custom'}
+                </button>
+              ))}
+            </div>
+
+            <input
+              type="password"
+              className="saas-input"
+              placeholder="API Key"
+              value={apiKey}
+              onChange={e => setApiKey(e.target.value)}
+              style={{ marginBottom: 8 }}
+              autoComplete="off"
+            />
+
+            {newProvider === 'custom' && (
+              <>
+                <input
+                  type="text"
+                  className="saas-input"
+                  placeholder="Base URL (e.g., https://api.openai.com/v1)"
+                  value={customBaseUrl}
+                  onChange={e => setCustomBaseUrl(e.target.value)}
+                  style={{ marginBottom: 8 }}
+                />
+                <input
+                  type="text"
+                  className="saas-input"
+                  placeholder="Model name"
+                  value={customModel}
+                  onChange={e => setCustomModel(e.target.value)}
+                />
+              </>
+            )}
+
+            <button className="saas-btn-primary" onClick={handleAddProvider} style={{ marginTop: 8 }}>
+              Save Provider
+            </button>
+          </div>
+        )}
+
+        {providers.length === 0 ? (
+          <p className="saas-hint">No AI providers configured. Add one to enable AI commands.</p>
+        ) : (
+          <div className="provider-list">
+            {providers.map(provider => (
+              <div key={provider.provider} className="provider-item" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ fontWeight: 500 }}>{provider.name}</span>
+                    <span style={{ fontSize: 12, opacity: 0.6 }}>
+                      {provider.model || providerDefaults[provider.provider].model}
+                    </span>
+                  </div>
+                  {editingKey === provider.provider ? (
+                    <div style={{ display: 'flex', gap: 4, marginTop: 4 }}>
+                      <input
+                        type="password"
+                        className="saas-input"
+                        style={{ fontSize: 12, padding: '4px 8px' }}
+                        value={editKeyValue}
+                        onChange={e => setEditKeyValue(e.target.value)}
+                        autoComplete="off"
+                      />
+                      <button className="saas-btn-primary" style={{ fontSize: 11, padding: '4px 8px' }} onClick={() => handleUpdateKey(provider.provider)}>Save</button>
+                      <button className="saas-btn-secondary" style={{ fontSize: 11, padding: '4px 8px' }} onClick={() => setEditingKey(null)}>Cancel</button>
+                    </div>
+                  ) : (
+                    <span
+                      style={{ fontSize: 11, opacity: 0.5, cursor: 'pointer', fontFamily: 'monospace' }}
+                      onClick={() => { setEditingKey(provider.provider); setEditKeyValue('') }}
+                      title="Click to change key"
+                    >
+                      {maskKey(provider.apiKey)}
+                    </span>
+                  )}
+                </div>
+                <div style={{ display: 'flex', gap: 8, flexShrink: 0, marginLeft: 12 }}>
+                  {activeProvider === provider.provider ? (
+                    <span style={{ color: 'var(--accent)', display: 'flex', alignItems: 'center', gap: 4, fontSize: 12 }}>
+                      <Check size={14} /> Active
+                    </span>
+                  ) : (
+                    <button className="saas-btn-secondary" onClick={() => setActive(provider.provider)} style={{ fontSize: 12 }}>
+                      Activate
+                    </button>
+                  )}
+                  <button className="saas-btn-icon" onClick={() => removeProvider(provider.provider)}>
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {activeProvider && (
+        <div className="saas-card">
+          <div className="saas-flex-row" style={{ justifyContent: 'space-between' }}>
+            <label className="saas-label" style={{ margin: 0 }}>Test Connection</label>
+            <button
+              className="saas-btn-secondary"
+              onClick={handleTestProvider}
+              disabled={testing}
+            >
+              {testing ? 'Testing...' : 'Test'}
+            </button>
+          </div>
+          {testResult && (
+            <p className="saas-hint" style={{ marginTop: 8, color: testResult.success ? 'var(--accent)' : '#ef4444', display: 'flex', alignItems: 'center', gap: 4 }}>
+              {testResult.success ? <Check size={14} /> : <AlertCircle size={14} />} {testResult.message}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="saas-card">
+        <label className="saas-label">Usage</label>
+        <p className="saas-hint">
+          Type <code style={{ background: 'rgba(255,255,255,0.1)', padding: '2px 6px', borderRadius: 4 }}>!</code> in the command palette to trigger AI mode.
+          <br /><br />
+          Examples:
+          <br />- <code>! open email and slack</code>
+          <br />- <code>! find that wiki page about auth</code>
+          <br />- <code>! search stack overflow for react hooks</code>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react'
-import { Settings, X, Plus, Check, Upload, Palette, Save, Monitor, Terminal, LayoutGrid, Hash, Trash2, Download, Cpu, AlertTriangle, Plug, ExternalLink } from 'lucide-react'
+import { Settings, X, Plus, Check, Upload, Palette, Save, Monitor, Terminal, LayoutGrid, Hash, Trash2, Download, Cpu, AlertTriangle, Plug, ExternalLink, Key } from 'lucide-react'
 import type { Settings as SettingsType, ThemeInfo, UrlAlias, StartupSite } from '../types'
 import { useStartupSites } from '../hooks/useStartupSites'
 import { convertImageToAscii } from '../utils/imageToAscii'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import { getConnectorsWithSettings, updateConnectorConfig } from '../connectors/registry'
+import { AIProviders } from './Settings/AIProviders'
+import { AIMemorySettings } from './Settings/AIMemory'
 
 const THEMES: ThemeInfo[] = [
   // Simple Color Themes
@@ -54,7 +56,7 @@ interface SettingsPanelProps {
   onAddCategory: (name: string) => void
 }
 
-type TabType = 'appearance' | 'preferences' | 'ascii' | 'widgets' | 'aliases' | 'startup' | 'integrations' | 'backup' | 'advanced';
+type TabType = 'appearance' | 'preferences' | 'ascii' | 'widgets' | 'aliases' | 'startup' | 'integrations' | 'backup' | 'advanced' | 'ai';
 
 export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: SettingsPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
@@ -245,6 +247,12 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                 >
                   <Cpu size={16} /> Advanced
                 </button>
+                <button
+                  className={`saas-nav-item ${activeTab === 'ai' ? 'active' : ''}`}
+                  onClick={() => setActiveTab('ai')}
+                >
+                  <Key size={16} /> AI
+                </button>
               </nav>
             </div>
 
@@ -261,6 +269,7 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                   {activeTab === 'integrations' && 'Integrations'}
                   {activeTab === 'backup' && 'Backup & Restore'}
                   {activeTab === 'advanced' && 'Advanced Settings'}
+                  {activeTab === 'ai' && 'AI & Command Interpreter'}
                 </h3>
               </div>
 
@@ -779,6 +788,19 @@ export function SettingsPanel({ settings, onSettingsChange, onAddCategory }: Set
                     </div>
                   </div>
                 )}
+                {/* AI TAB */}
+                {activeTab === 'ai' && (
+                  <>
+                    <AIProviders
+                      _settings={localSettings}
+                      _onSettingsChange={handleChange}
+                    />
+                    <div className="saas-section">
+                      <AIMemorySettings />
+                    </div>
+                  </>
+                )}
+
                 {/* ADVANCED TAB */}
                 {activeTab === 'advanced' && (
                   <div className='saas-section'>

--- a/src/hooks/useAIMemory.ts
+++ b/src/hooks/useAIMemory.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { AIMemory } from '../types'
+
+const STORAGE_KEY = 'neko-ai-memories'
+
+async function read(): Promise<AIMemory[]> {
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    const stored = await chrome.storage.local.get(STORAGE_KEY)
+    return (stored[STORAGE_KEY] ?? []) as AIMemory[]
+  }
+  const raw = localStorage.getItem(STORAGE_KEY)
+  return raw ? JSON.parse(raw) : []
+}
+
+async function write(memories: AIMemory[]): Promise<void> {
+  if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+    await chrome.storage.local.set({ [STORAGE_KEY]: memories })
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(memories))
+}
+
+export function useAIMemory() {
+  const [memories, setMemories] = useState<AIMemory[]>([])
+
+  useEffect(() => {
+    read().then(setMemories)
+  }, [])
+
+  const saveMemory = useCallback(async (keyword: string, url: string, source: AIMemory['source']) => {
+    const existing = await read()
+    const idx = existing.findIndex(m => m.keyword === keyword)
+    const entry: AIMemory = {
+      keyword,
+      url,
+      usageCount: idx >= 0 ? existing[idx].usageCount + 1 : 1,
+      lastUsed: Date.now(),
+      source,
+    }
+    const updated = idx >= 0
+      ? [...existing.slice(0, idx), entry, ...existing.slice(idx + 1)]
+      : [...existing, entry]
+    await write(updated)
+    setMemories(updated)
+    return entry
+  }, [])
+
+  const deleteMemory = useCallback(async (keyword: string) => {
+    const existing = await read()
+    const updated = existing.filter(m => m.keyword !== keyword)
+    await write(updated)
+    setMemories(updated)
+  }, [])
+
+  const updateMemory = useCallback(async (keyword: string, updates: Partial<AIMemory>) => {
+    const existing = await read()
+    const idx = existing.findIndex(m => m.keyword === keyword)
+    if (idx < 0) return
+    const updated = [...existing]
+    updated[idx] = { ...updated[idx], ...updates }
+    await write(updated)
+    setMemories(updated)
+  }, [])
+
+  const clearAll = useCallback(async () => {
+    await write([])
+    setMemories([])
+  }, [])
+
+  return { memories, saveMemory, deleteMemory, updateMemory, clearAll }
+}

--- a/src/hooks/useAIProviders.ts
+++ b/src/hooks/useAIProviders.ts
@@ -1,0 +1,204 @@
+import { useState, useCallback } from 'react'
+import type { AIProvider, AIProviderConfig, AIAction } from '../types'
+
+const PROVIDER_DEFAULTS: Record<AIProvider, { name: string; baseUrl: string; model: string }> = {
+  openai: { name: 'OpenAI', baseUrl: 'https://api.openai.com/v1', model: 'gpt-4o-mini' },
+  anthropic: { name: 'Anthropic', baseUrl: 'https://api.anthropic.com/v1', model: 'claude-3-haiku-20240307' },
+  gemini: { name: 'Google Gemini', baseUrl: 'https://generativelanguage.googleapis.com/v1', model: 'gemini-2.5-flash' },
+  custom: { name: 'Custom API', baseUrl: '', model: '' },
+}
+
+function sanitize(str: string): string {
+  return str.replace(/[\x00-\x1F\x7F]/g, '').slice(0, 200)
+}
+
+export function useAIProviders() {
+  const [providers, setProviders] = useState<AIProviderConfig[]>([])
+  const [activeProvider, setActiveProvider] = useState<AIProvider | null>(null)
+
+  const loadProviders = useCallback(async () => {
+    if (typeof chrome === 'undefined' || !chrome.storage?.local) return
+
+    const stored = await chrome.storage.local.get('ai-providers') as { 'ai-providers'?: AIProviderConfig[] }
+    if (stored['ai-providers']) {
+      setProviders(stored['ai-providers'])
+    }
+
+    const active = await chrome.storage.local.get('ai-active-provider') as { 'ai-active-provider'?: AIProvider }
+    if (active['ai-active-provider']) {
+      setActiveProvider(active['ai-active-provider'])
+    }
+  }, [])
+
+  const saveProvider = useCallback(async (provider: AIProviderConfig) => {
+    setProviders(prev => {
+      const filtered = prev.filter(p => p.provider !== provider.provider)
+      const updated = [...filtered, provider]
+
+      if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+        chrome.storage.local.set({ 'ai-providers': updated })
+      }
+
+      return updated
+    })
+  }, [])
+
+  const removeProvider = useCallback(async (provider: AIProvider) => {
+    setProviders(prev => {
+      const updated = prev.filter(p => p.provider !== provider)
+
+      if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+        chrome.storage.local.set({ 'ai-providers': updated })
+      }
+
+      return updated
+    })
+
+    if (activeProvider === provider) {
+      setActiveProvider(null)
+      if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+        chrome.storage.local.set({ 'ai-active-provider': null })
+      }
+    }
+  }, [activeProvider])
+
+  const setActive = useCallback(async (provider: AIProvider | null) => {
+    setActiveProvider(provider)
+    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
+      chrome.storage.local.set({ 'ai-active-provider': provider })
+    }
+  }, [])
+
+  const executeCommand = useCallback(async (
+    prompt: string,
+    context: { aliases: string; bookmarks: string; tabs: string; history: string; memories: string }
+  ): Promise<AIAction[]> => {
+    const currentActive = activeProvider
+    if (!currentActive) {
+      throw new Error('No active AI provider configured')
+    }
+
+    const providerConfig = providers.find(p => p.provider === currentActive)
+    if (!providerConfig?.apiKey) {
+      throw new Error(`API key not set for ${currentActive}`)
+    }
+
+    const defaults = PROVIDER_DEFAULTS[currentActive]
+    const baseUrl = providerConfig.baseUrl || defaults.baseUrl
+    const model = providerConfig.model && providerConfig.model !== 'gemini-1.5-flash' ? providerConfig.model : defaults.model
+
+    const safeQuery = sanitize(prompt)
+
+    const systemPrompt = `You are a command interpreter. Given the user's context and request, respond with a JSON array of actions.
+
+You are a command interpreter. Given the user's context and request, respond with a JSON array of actions.
+
+When the user says "open X", check the known destinations first. If X matches a known destination, use its exact URL. For example:
+- "open slack" → {"type": "open_url", "value": "https://slack.com"}
+- "open slack and discord" → {"type": "open_tabs", "value": "https://slack.com, https://discord.com"}
+- "open gmail" → {"type": "open_url", "value": "https://mail.google.com"}
+- "open youtube" → {"type": "open_url", "value": "https://youtube.com"}
+- "open google docs my resume" → {"type": "search", "value": "my resume google docs"}
+
+If you open a URL that isn't in known destinations, append a remember action so the system learns it.
+
+Only use "search" when you genuinely don't know the URL. Prefer "open_url" for known websites.
+
+Context:
+<context>
+aliases: ${sanitize(context.aliases)}
+bookmarks: ${sanitize(context.bookmarks)}
+open tabs: ${sanitize(context.tabs)}
+recent history: ${sanitize(context.history)}
+known destinations:
+${sanitize(context.memories)}
+</context>
+
+User request:
+<user_query>${safeQuery}</user_query>
+
+Available actions:
+- {"type": "open_url", "value": "<full url>"} — navigate to a URL
+- {"type": "search", "value": "<search query>"} — Google search (only when URL is unknown)
+- {"type": "open_tabs", "value": "<url1>, <url2>, ..."} — open multiple URLs in new tabs
+- {"type": "alias", "value": "<alias key>"} — use a saved alias
+- {"type": "history", "value": "<search term for chrome history>"} — search browser history
+- {"type": "remember", "value": "<keyword>", "url": "<full url>"} — save a new memory mapping
+
+Respond ONLY with a valid JSON array. No markdown, no explanation.`
+
+    let response: Response
+
+    if (currentActive === 'gemini') {
+      response = await fetch(`${baseUrl}/models/${model}:generateContent?key=${providerConfig.apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ parts: [{ text: systemPrompt }] }] }),
+      })
+    } else if (currentActive === 'openai' || currentActive === 'custom') {
+      response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${providerConfig.apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: 'user', content: systemPrompt }],
+          temperature: 0.3,
+        }),
+      })
+    } else if (currentActive === 'anthropic') {
+      response = await fetch(`${baseUrl}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': providerConfig.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: systemPrompt }],
+        }),
+      })
+    } else {
+      throw new Error(`Unknown provider: ${currentActive}`)
+    }
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`AI API error: ${response.status} — ${error}`)
+    }
+
+    const data = await response.json()
+    let content = ''
+
+    if (currentActive === 'openai' || currentActive === 'custom') {
+      content = data.choices?.[0]?.message?.content || ''
+    } else if (currentActive === 'anthropic') {
+      content = data.content?.[0]?.text || ''
+    } else if (currentActive === 'gemini') {
+      content = data.candidates?.[0]?.content?.parts?.[0]?.text || ''
+    }
+
+    const jsonMatch = content.match(/\[[\s\S]*\]/)
+    if (!jsonMatch) {
+      throw new Error('AI response was not valid JSON')
+    }
+
+    const actions = JSON.parse(jsonMatch[0]) as AIAction[]
+    return actions
+  }, [activeProvider, providers])
+
+  return {
+    providers,
+    activeProvider,
+    loadProviders,
+    saveProvider,
+    removeProvider,
+    setActive,
+    executeCommand,
+    providerDefaults: PROVIDER_DEFAULTS,
+  }
+}

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -267,6 +267,22 @@
   vertical-align: middle;
 }
 
+/* AI command result */
+.cp-item-ai {
+  border-left: 3px solid var(--accent);
+}
+
+.cp-item-ai .cp-item-label {
+  font-weight: 600;
+}
+
+.cp-ai-error {
+  padding: 8px 16px;
+  color: #ef4444;
+  font-size: 12px;
+  border-top: 1px solid rgba(255,255,255,0.1);
+}
+
 /* glass mode — trigger bar */
 .has-bg .cp-trigger {
   background: transparent;
@@ -316,5 +332,27 @@
   from { opacity: 0; transform: translateX(-50%) translateY(8px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+/* AI thinking dots */
+.cp-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 14px;
+}
+.cp-dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: cp-dot-pulse 1.2s ease-in-out infinite;
+}
+.cp-dots span:nth-child(1) { animation-delay: 0s; }
+.cp-dots span:nth-child(2) { animation-delay: 0.2s; }
+.cp-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes cp-dot-pulse {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.7); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
 /* --- NEW FOCUS MODE REDESIGN --- */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,3 +78,33 @@ export interface TabItem {
   favicon?: string
   windowId: number
 }
+
+export type AIProvider = 'openai' | 'anthropic' | 'gemini' | 'custom'
+
+export interface AIProviderConfig {
+  provider: AIProvider
+  name: string
+  apiKey: string
+  baseUrl?: string
+  model?: string
+}
+
+export interface AIMemory {
+  keyword: string
+  url: string
+  usageCount: number
+  lastUsed: number
+  source: 'history' | 'ai' | 'manual'
+}
+
+export interface AIAction {
+  type: 'open_url' | 'search' | 'alias' | 'open_tabs' | 'history' | 'remember' | 'custom'
+  value: string
+  url?: string
+}
+
+export interface AISettings {
+  enabledProviders: AIProvider[]
+  activeProvider: AIProvider | null
+  customPrompt?: string
+}

--- a/src/utils/ai-command-parser.ts
+++ b/src/utils/ai-command-parser.ts
@@ -1,0 +1,155 @@
+import type { AIAction, AIMemory } from '../types'
+
+const VALID_TYPES = new Set(['open_url', 'search', 'alias', 'open_tabs', 'history', 'remember', 'custom'])
+
+export function parseAIActions(response: string): AIAction[] {
+  try {
+    const jsonMatch = response.match(/\[[\s\S]*\]/)
+    if (!jsonMatch) {
+      console.error('No JSON array found in AI response')
+      return []
+    }
+
+    const actions = JSON.parse(jsonMatch[0]) as AIAction[]
+
+    return actions.filter(action =>
+      action.type && action.value && VALID_TYPES.has(action.type)
+    )
+  } catch (error) {
+    console.error('Failed to parse AI response:', error)
+    return []
+  }
+}
+
+export async function executeActions(actions: AIAction[]): Promise<void> {
+  for (const action of actions) {
+    if (action.type === 'remember') continue
+
+    await new Promise(resolve => setTimeout(resolve, 300))
+
+    switch (action.type) {
+      case 'open_url': {
+        const url = action.value.startsWith('http') ? action.value : `https://${action.value}`
+        if (typeof chrome !== 'undefined' && chrome.tabs) {
+          chrome.tabs.create({ url })
+        } else {
+          window.location.href = url
+          return
+        }
+        break
+      }
+
+      case 'search': {
+        const searchUrl = `https://www.google.com/search?q=${encodeURIComponent(action.value)}`
+        if (typeof chrome !== 'undefined' && chrome.tabs) {
+          chrome.tabs.create({ url: searchUrl })
+        } else {
+          window.location.href = searchUrl
+          return
+        }
+        break
+      }
+
+      case 'alias':
+        window.location.href = action.value
+        return
+
+      case 'open_tabs': {
+        const urls = action.value.split(',').map(u => u.trim())
+        if (typeof chrome !== 'undefined' && chrome.tabs) {
+          for (const url of urls) {
+            if (url) {
+              chrome.tabs.create({ url: url.startsWith('http') ? url : `https://${url}` })
+            }
+          }
+        }
+        break
+      }
+
+      case 'history':
+        if (typeof chrome !== 'undefined' && chrome.history) {
+          chrome.history.search({ text: action.value, maxResults: 5 }, results => {
+            if (results[0]?.url) {
+              window.location.href = results[0].url
+            }
+          })
+        }
+        break
+
+      case 'custom':
+        console.log('Custom AI action:', action.value)
+        break
+    }
+  }
+}
+
+export async function fetchFrequentDestinations(): Promise<AIMemory[]> {
+  if (typeof chrome === 'undefined' || !chrome.history) return []
+
+  try {
+    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000
+    const items = await new Promise<chrome.history.HistoryItem[]>((resolve) => {
+      chrome.history.search({ text: '', maxResults: 200, startTime: thirtyDaysAgo }, resolve)
+    })
+
+    const domainMap = new Map<string, Map<string, number>>()
+    for (const item of items) {
+      if (!item.url || item.url.startsWith('chrome://') || item.url.startsWith('chrome-extension://')) continue
+      try {
+        const url = new URL(item.url)
+        const domain = url.hostname.replace(/^www\./, '')
+        if (!domainMap.has(domain)) domainMap.set(domain, new Map())
+        const urlMap = domainMap.get(domain)!
+        urlMap.set(item.url, (urlMap.get(item.url) || 0) + (item.visitCount || 1))
+      } catch { }
+    }
+
+    const result: AIMemory[] = []
+    for (const [domain, urlMap] of domainMap) {
+      let bestUrl = ''
+      let bestCount = 0
+      for (const [url, count] of urlMap) {
+        if (count > bestCount) {
+          bestCount = count
+          bestUrl = url
+        }
+      }
+      if (bestUrl) {
+        result.push({
+          keyword: domain,
+          url: bestUrl,
+          usageCount: bestCount,
+          lastUsed: Date.now(),
+          source: 'history',
+        })
+      }
+    }
+
+    result.sort((a, b) => b.usageCount - a.usageCount)
+    return result.slice(0, 30)
+  } catch {
+    return []
+  }
+}
+
+function strip(str: string): string {
+  return str.replace(/[\x00-\x1F\x7F]/g, '').slice(0, 200)
+}
+
+export function buildContext(
+  aliases: { key: string; url: string }[],
+  categories: { name: string; bookmarks: { title: string; url: string }[] }[],
+  tabs: { title: string; url: string }[],
+  history: { title: string; url: string }[],
+  memories: AIMemory[] = [],
+): { aliases: string; bookmarks: string; tabs: string; history: string; memories: string } {
+  return {
+    aliases: aliases.map(a => `${a.key} -> ${a.url}`).join(', '),
+    bookmarks: categories.flatMap(c =>
+      c.bookmarks.map(b => `${b.title}: ${b.url}`)
+    ).map(s => strip(s)).join('; '),
+    tabs: tabs.map(t => strip(t.title)).join(', '),
+    history: history.map(h => strip(h.title)).join(', '),
+    memories: memories.map(m => `${m.keyword} -> ${m.url}`).join('\n'),
+  }
+}


### PR DESCRIPTION
## Summary
- **AI command mode** — type `!` in the command palette to trigger natural language navigation via OpenAI, Anthropic, Gemini, or custom API
- **AI Memory** — persistent learning system that scans Chrome history, auto-learns from usage, and accepts AI-suggested URL mappings stored in `chrome.storage.local`
- **Memory management UI** — view, search, edit, delete learned mappings in **Settings → AI → AI Memory**
- **Better UX** — palette stays open with animated thinking indicator during AI processing, shows errors inline, executes multiple actions via `chrome.tabs.create`

## Side effects / things to watch
- `chrome.history.search` is called once per palette open (200 items, last 30 days) to seed memories — cached in-memory so only runs once per session
- Old saved provider configs with `gemini-1.5-flash` model are automatically ignored (migration)
- New dependency: `useAIMemory` hook — other features can import it if needed

## Test Plan
- [ ] `!open slack` — should open your most visited slack URL (or slack.com if no history)
- [ ] `!open slack and discord` — opens both in new tabs
- [ ] Check **Settings → AI** for AI Memory table after running commands
- [ ] Edit/delete individual memories in settings
- [ ] Verify palette shows animated dots while AI is processing
- [ ] Verify palette stays open on error and shows message