### PR TITLE
feat: add ChatGPT and Claude themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The AI learns from your browsing patterns over time:
 
 ### Theming
 
-20+ professionally crafted themes across three categories:
+22+ professionally crafted themes across three categories:
 
-- **Color**: Carbon, Paper, Nord, Solarized, Matrix, Dracula, Monokai, Gruvbox, Tokyo Night, Catppuccin, One Dark, Rosé Pine, Everforest
+- **Color**: Carbon, Paper, Nord, Solarized, Matrix, Dracula, Monokai, Gruvbox, Tokyo Night, Catppuccin, One Dark, Rosé Pine, Everforest, ChatGPT, Claude
 - **Animated**: Cyberpunk, Aurora, Synthwave, Vaporwave
 - **Special Effects**: Retro CRT, Sunset, Ocean, Midnight
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -198,6 +198,7 @@ const THEME_LIST: { id: ThemeType; name: string }[] = [
   { id: 'synthwave', name: 'Synthwave' }, { id: 'vaporwave', name: 'Vaporwave' },
   { id: 'retro-terminal', name: 'Retro CRT' }, { id: 'sunset', name: 'Sunset' },
   { id: 'ocean', name: 'Ocean' }, { id: 'midnight', name: 'Midnight' },
+  { id: 'chatgpt', name: 'ChatGPT' }, { id: 'claude', name: 'Claude' },
 ]
 
 const FONT_LIST = [

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -33,6 +33,9 @@ const THEMES: ThemeInfo[] = [
   { id: 'sunset', name: 'Sunset', bgColor: '#1a1423', textColor: '#ffecd2', accentColor: '#fcb69f', category: 'special' },
   { id: 'ocean', name: 'Ocean', bgColor: '#0c1821', textColor: '#ccd6f6', accentColor: '#64ffda', category: 'special' },
   { id: 'midnight', name: 'Midnight', bgColor: '#020617', textColor: '#e2e8f0', accentColor: '#6366f1', category: 'special' },
+  // AI-Inspired Themes
+  { id: 'chatgpt', name: 'ChatGPT', bgColor: '#212121', textColor: '#ECECF1', accentColor: '#10A37F', category: 'color' },
+  { id: 'claude', name: 'Claude', bgColor: '#1C1C1C', textColor: '#E8E8E8', accentColor: '#C9773A', category: 'color' },
 ]
 
 const FONTS = [

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -33,6 +33,8 @@
 .cp-panel.sunset      { --bg-primary:#1a1423; --bg-tertiary:#251d30; --text-primary:#ffecd2; --text-secondary:#fcb69f; --accent:#fcb69f; --border:#3a2f45; }
 .cp-panel.ocean       { --bg-primary:#0c1821; --bg-tertiary:#142533; --text-primary:#ccd6f6; --text-secondary:#8892b0; --accent:#64ffda; --border:#233554; }
 .cp-panel.midnight    { --bg-primary:#020617; --bg-tertiary:#0f172a; --text-primary:#e2e8f0; --text-secondary:#94a3b8; --accent:#6366f1; --border:#1e293b; }
+.cp-panel.chatgpt     { --bg-primary:#212121; --bg-tertiary:#2D2D2D; --text-primary:#ECECF1; --text-secondary:#8E8EA0; --accent:#10A37F; --border:#4D4D4F; }
+.cp-panel.claude      { --bg-primary:#1C1C1C; --bg-tertiary:#2D2D2D; --text-primary:#E8E8E8; --text-secondary:#9CA3AF; --accent:#C9773A; --border:#3A3A3A; }
 
 .cp-panel {
   width: 580px;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -181,6 +181,34 @@
 }
 
 
+/* ChatGPT Theme */
+.app.chatgpt {
+  --bg-primary: #212121;
+  --bg-secondary: #171717;
+  --bg-tertiary: #2D2D2D;
+  --text-primary: #ECECF1;
+  --text-secondary: #8E8EA0;
+  --accent: #10A37F;
+  --accent-hover: #1A7F64;
+  --border: #4D4D4F;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+/* Claude Theme */
+.app.claude {
+  --bg-primary: #1C1C1C;
+  --bg-secondary: #141414;
+  --bg-tertiary: #2D2D2D;
+  --text-primary: #E8E8E8;
+  --text-secondary: #9CA3AF;
+  --accent: #C9773A;
+  --accent-hover: #D68B4F;
+  --border: #3A3A3A;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
 /* Legacy support */
 .app.dark {
   --bg-primary: #222526;

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,8 @@ export type ThemeType =
   | 'cyberpunk' | 'aurora' | 'synthwave' | 'vaporwave'
   // Special Effect Themes
   | 'retro-terminal' | 'sunset' | 'ocean' | 'midnight'
+  // AI-Inspired Themes
+  | 'chatgpt' | 'claude'
 
 export interface ThemeInfo {
   id: ThemeType


### PR DESCRIPTION
Adds two new AI-inspired dark themes to the theme picker:

- **ChatGPT** — dark charcoal with green accent (#10A37F), mimicking ChatGPT's dark UI
- **Claude** — warm dark with amber accent (#C9773A), mimicking Claude's dark UI

Both themes are available in the Settings → Appearance panel and via /theme slash command.