### PR TITLE
fix: validate AI answer chip URLs and move Gemini test key to header

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -866,6 +866,7 @@ export function CommandPalette() {
                         key={i}
                         className="cp-chip"
                         onClick={() => {
+                          if (!isSafeUrl(u.url)) return
                           if (typeof chrome !== 'undefined' && chrome.tabs) {
                             chrome.tabs.create({ url: u.url })
                           } else {

--- a/src/components/Settings/AIProviders.tsx
+++ b/src/components/Settings/AIProviders.tsx
@@ -89,8 +89,8 @@ export function AIProviders() {
           body: JSON.stringify({ model: provider.model || 'claude-3-haiku-20240307', max_tokens: 1, messages: [{ role: 'user', content: 'hi' }] }),
         })
       } else if (providerType === 'gemini') {
-        response = await fetch(`${baseUrl}/models?key=${provider.apiKey}`, {
-          headers: { 'Content-Type': 'application/json' },
+        response = await fetch(`${baseUrl}/models`, {
+          headers: { 'Content-Type': 'application/json', 'x-goog-api-key': provider.apiKey },
         })
       } else {
         throw new Error(`Unknown provider: ${providerType}`)


### PR DESCRIPTION
Two security fixes from audit:

- **AI answer chip URLs**: Added `isSafeUrl()` validation before passing AI-returned URLs to `chrome.tabs.create()` / `window.location.href`. Prevents `javascript:` URI injection from adversarial AI responses.

- **Gemini test connection**: Moved API key from URL query param (`?key=...`) to `x-goog-api-key` header in the Settings test endpoint, matching the `executeCommand` path fixed in `8874440`.

No side effects — both are narrow validation/transport changes.