### PR TITLE
Gmail connector + AI inbox digest, search bar visibility, README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,9 @@ Run with browser fully closed. Then reopen and Load unpacked → `dist/`.
 | `neko-gh-streak-{user}` | cached GitHub streak data |
 | `neko-calendar-connected` | `'true'` or `'false'` string |
 | `neko-calendar-last-event` | JSON CalendarEvent or absent |
+| `neko-gmail-connected` | `'true'` or `'false'` string |
+| `neko-gmail-last-emails` | `{ emails: GmailEmail[], unreadCount }` |
+| `neko-gmail-digest` | `{ text, date, lastAttempt? }` AI inbox digest |
 
 ## Connector System (Integrations)
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ See your next upcoming event directly on the new tab page, right below the clock
 - Disconnect anytime from the same settings panel
 - Chrome only — requires the `identity` API
 
+### Gmail Integration
+
+See your unread email at a glance, right below the clock.
+
+- Connect your Google account from **Settings → Integrations → Gmail** (read-only scope)
+- Shows unread count plus the latest unread emails (sender, subject, snippet)
+- Optional AI-powered inbox digest that summarizes what needs attention
+- Refreshes automatically every 5 minutes, cached between sessions
+- Disconnect anytime from the same settings panel
+- Chrome only — requires the `identity` API
+
 ### Daily Goal
 
 A single focus line between the clock and command palette. Click to edit, resets at midnight.
@@ -187,15 +198,15 @@ npm run build
 
 Then in Chrome/Edge: **Extensions → Load unpacked → select the `dist/` folder**.
 
-### Optional: Google Calendar Integration
+### Optional: Google Calendar / Gmail Integration
 
-The extension works fully without any setup. To enable Google Calendar events on your new tab page:
+The extension works fully without any setup. To enable Google Calendar events and the Gmail unread widget on your new tab page:
 
 1. Copy `.env.local.example` to `.env.local`
 2. Follow the instructions in `.env.local.example` to add your Google OAuth credentials
 3. Rebuild with `npm run build`
 
-Without credentials, the extension runs normally — just without Calendar support. No unnecessary permissions are requested.
+Without credentials, the extension runs normally — just without Calendar and Gmail support. No unnecessary permissions are requested.
 
 ---
 
@@ -210,7 +221,7 @@ Open the gear icon (top-right) to access:
 - **AI** — configure AI providers (OpenAI, Anthropic, Gemini, custom API), manage learned URL memories
 - **Aliases** — define short URL aliases for the command palette
 - **Startup Sites** — configure up to 10 URLs to open on the first new tab of each day
-- **Integrations** — connect Google Calendar to show upcoming events on the home page
+- **Integrations** — connect Google Calendar to show upcoming events, and Gmail to see unread mail with an optional AI inbox summary
 - **Export/Import** — download all settings as JSON or restore from a backup
 - **Advanced** — reset all user data and wipe stored settings cleanly
 - **Support** — buy me a coffee ☕
@@ -229,7 +240,7 @@ Open the gear icon (top-right) to access:
 | `webRequest` | Track tab navigation for the tab usage counter |
 | `declarativeNetRequest` | Block sites during Focus Mode sessions |
 | `host_permissions: <all_urls>` | Required for site blocking to apply on any domain |
-| `identity` | OAuth flow for Google Calendar integration (Chrome only) — only included in the built extension if credentials are configured |
+| `identity` | OAuth flow for Google Calendar and Gmail integrations (Chrome only) — only included in the built extension if credentials are configured |
 
 ---
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,7 +29,8 @@
   "oauth2": {
     "client_id": "__GOOGLE_CLIENT_ID__",
     "scopes": [
-      "https://www.googleapis.com/auth/calendar.events.readonly"
+      "https://www.googleapis.com/auth/calendar.events.readonly",
+      "https://www.googleapis.com/auth/gmail.readonly"
     ]
   },
   "host_permissions": [

--- a/src/connectors/gmail/GmailDigest.tsx
+++ b/src/connectors/gmail/GmailDigest.tsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Mail, Sparkles, RefreshCw } from 'lucide-react';
+import { useGmail, type GmailEmail } from './useGmail';
+import { useSettings } from '../../hooks/useLocalStorage';
+import { getConnectorConfig } from '../types';
+import { useAIProviders } from '../../hooks/useAIProviders';
+
+const CONNECTOR_ID = 'gmail';
+const GMAIL_URL = 'https://mail.google.com';
+
+interface StoredDigest {
+  text: string;
+  date: string; // YYYY-MM-DD the digest was generated for
+  lastAttempt?: string; // YYYY-MM-DD of last auto-attempt (avoids retry spam)
+}
+
+function readDigest(): StoredDigest | null {
+  try {
+    const cached = localStorage.getItem('neko-gmail-digest');
+    if (cached) return JSON.parse(cached);
+  } catch { /* ignore corrupt cache */ }
+  return null;
+}
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function buildPrompt(emails: GmailEmail[]): string {
+  const list = emails
+    .map((e, i) => `${i + 1}. From: ${e.from} | Subject: ${e.subject} | Preview: ${e.snippet}`)
+    .join('\n');
+  return `Summarize the user's unread email inbox. Group by what matters: urgent/personal first, then newsletters/notifications. Reply in 2-4 short plain-text lines, no markdown formatting. Mention sender names where useful.
+
+Unread emails:
+${list}`;
+}
+
+export function GmailDigest() {
+  const [settings] = useSettings();
+  const config = getConnectorConfig(settings, CONNECTOR_ID);
+  const enabled = !!config.enabled;
+
+  const { emails, unreadCount, isConnected, error } = useGmail(enabled);
+
+  const [digest, setDigest] = useState<StoredDigest | null>(readDigest);
+  const [summarizing, setSummarizing] = useState(false);
+  const [digestError, setDigestError] = useState<string | null>(null);
+  const [wasConnected] = useState(() => localStorage.getItem('neko-gmail-connected') === 'true');
+  const autoAttempted = useRef(false);
+
+  const { loadProviders, completeText, activeProvider } = useAIProviders();
+
+  useEffect(() => {
+    loadProviders();
+  }, [loadProviders]);
+
+  const summarize = useCallback(async () => {
+    if (!activeProvider || summarizing || emails.length === 0) return;
+    setSummarizing(true);
+    setDigestError(null);
+    try {
+      const text = await completeText(buildPrompt(emails));
+      const next: StoredDigest = { text: text.trim(), date: todayKey(), lastAttempt: todayKey() };
+      setDigest(next);
+      localStorage.setItem('neko-gmail-digest', JSON.stringify(next));
+    } catch (err: any) {
+      setDigestError(err.message);
+      const stored = readDigest();
+      const next: StoredDigest = { ...(stored ?? { text: '', date: '' }), lastAttempt: todayKey() };
+      localStorage.setItem('neko-gmail-digest', JSON.stringify(next));
+    } finally {
+      setSummarizing(false);
+    }
+  }, [activeProvider, summarizing, emails, completeText]);
+
+  // Auto-summarize once per morning: first mount of a new day with unread mail
+  useEffect(() => {
+    const today = todayKey();
+    if (
+      !autoAttempted.current &&
+      isConnected &&
+      activeProvider &&
+      emails.length > 0 &&
+      digest?.date !== today &&
+      digest?.lastAttempt !== today
+    ) {
+      autoAttempted.current = true;
+      summarize();
+    }
+  }, [isConnected, activeProvider, emails, digest, summarize]);
+
+  if (!enabled || (!isConnected && !wasConnected)) {
+    return null;
+  }
+
+  return (
+    <div
+      className="gmail-digest-widget"
+      style={{
+        maxWidth: '560px',
+        margin: '0 auto',
+        padding: '12px 16px',
+        border: '1px solid var(--border-color, rgba(128,128,128,0.3))',
+        borderRadius: '6px',
+        fontSize: '0.85rem',
+      }}
+    >
+      <a
+        href={GMAIL_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          color: 'var(--text-color)',
+          textDecoration: 'none',
+          opacity: 0.9,
+        }}
+      >
+        <Mail size={14} color="var(--accent-color)" />
+        <span style={{ fontWeight: 500 }}>
+          gmail{unreadCount > 0 ? ` — ${unreadCount} unread` : ' — inbox zero'}
+        </span>
+      </a>
+
+      {emails.length > 0 && (
+        <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0' }}>
+          {emails.slice(0, 5).map((email) => (
+            <li key={email.id} style={{ display: 'flex', gap: '8px', lineHeight: 1.6 }}>
+              <span style={{ opacity: 0.6, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '140px' }}>
+                {email.from}
+              </span>
+              <a
+                href={GMAIL_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--text-color)', textDecoration: 'none', opacity: 0.75, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                title={email.subject}
+              >
+                {email.subject}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(digest?.text || summarizing || digestError || unreadCount > 0) && (
+        <div style={{ marginTop: '10px', paddingTop: '10px', borderTop: '1px dashed var(--border-color, rgba(128,128,128,0.3))' }}>
+          {summarizing && (
+            <span style={{ opacity: 0.7, display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+              <RefreshCw size={12} /> summarizing…
+            </span>
+          )}
+          {!summarizing && digest?.text && (
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap', opacity: 0.85 }}>{digest.text}</p>
+          )}
+          {digestError && (
+            <p style={{ margin: 0, color: '#ff4444', fontSize: '0.8rem' }}>summary failed: {digestError}</p>
+          )}
+          {!summarizing && unreadCount > 0 && (
+            <button
+              onClick={summarize}
+              disabled={!activeProvider}
+              title={activeProvider ? 'Regenerate AI summary' : 'Configure an AI provider in Settings → AI'}
+              style={{
+                marginTop: '6px',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+                color: 'var(--accent-color)',
+                fontSize: '0.8rem',
+                cursor: activeProvider ? 'pointer' : 'not-allowed',
+                opacity: activeProvider ? 0.8 : 0.4,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              <Sparkles size={12} />
+              {digest?.text ? 're-summarize' : 'ai summary'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <p style={{ margin: '8px 0 0', color: '#ff4444', fontSize: '0.8rem' }}>gmail: {error}</p>
+      )}
+    </div>
+  );
+}

--- a/src/connectors/gmail/GmailDigest.tsx
+++ b/src/connectors/gmail/GmailDigest.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Mail, Sparkles, RefreshCw, ChevronDown } from 'lucide-react';
 import { useGmail, type GmailEmail } from './useGmail';
 import { useSettings } from '../../hooks/useLocalStorage';
@@ -37,10 +38,163 @@ Unread emails:
 ${list}`;
 }
 
+interface DropdownContentProps {
+  emails: GmailEmail[];
+  unreadCount: number;
+  digest: StoredDigest | null;
+  summarizing: boolean;
+  digestError: string | null;
+  activeProvider: any;
+  summarize: () => void;
+  buttonRef: React.RefObject<HTMLButtonElement>;
+  showAISummary: boolean;
+}
+
+function DropdownContent({
+  emails,
+  unreadCount,
+  digest,
+  summarizing,
+  digestError,
+  activeProvider,
+  summarize,
+  buttonRef,
+  showAISummary,
+}: DropdownContentProps) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const button = buttonRef.current;
+    if (!button || !dropdownRef.current) return;
+
+    const rect = button.getBoundingClientRect();
+    const dropdown = dropdownRef.current;
+    const dropdownWidth = 520;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = rect.left + rect.width / 2 - dropdownWidth / 2;
+    const maxLeft = viewportWidth - dropdownWidth - 16;
+    const minLeft = 16;
+    left = Math.max(minLeft, Math.min(left, maxLeft));
+
+    const top = rect.bottom + 4;
+    const dropdownHeight = Math.min(600, viewportHeight * 0.6);
+    const maxTop = viewportHeight - dropdownHeight - 16;
+
+    dropdown.style.left = `${left}px`;
+    dropdown.style.top = `${Math.min(top, maxTop)}px`;
+    dropdown.style.width = `${dropdownWidth}px`;
+    dropdown.style.maxHeight = `${dropdownHeight}px`;
+  }, [buttonRef]);
+
+  return (
+    <div
+      ref={dropdownRef}
+      data-gmail-dropdown
+      style={{
+        position: 'fixed',
+        zIndex: 9999,
+        background: 'var(--bg-color, #111)',
+        border: '1px solid rgba(128,128,128,0.35)',
+        borderRadius: '6px',
+        padding: '14px 16px',
+        textAlign: 'left',
+        boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+        overflowY: 'auto',
+        maxWidth: '90vw',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+        <span style={{ fontWeight: 500, fontSize: '0.85rem' }}>
+          inbox{unreadCount > 0 ? ` — ${unreadCount} unread` : ''}
+        </span>
+        <a
+          href={GMAIL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: 'var(--accent-color)', textDecoration: 'none', fontSize: '0.78rem', opacity: 0.85 }}
+        >
+          open gmail ↗
+        </a>
+      </div>
+
+      {!showAISummary && (
+        <>
+          {emails.length > 0 ? (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {emails.slice(0, 8).map((email) => (
+                <li key={email.id} style={{ lineHeight: 1.7 }}>
+                  <a
+                    href={GMAIL_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ display: 'flex', gap: '10px', color: 'var(--text-color)', textDecoration: 'none', opacity: 0.8 }}
+                    title={`${email.from}: ${email.subject}`}
+                  >
+                    <span style={{ opacity: 0.65, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '150px', flexShrink: 0 }}>
+                      {email.from}
+                    </span>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {email.subject}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p style={{ margin: 0, opacity: 0.6, fontSize: '0.82rem' }}>inbox zero — nothing unread</p>
+          )}
+        </>
+      )}
+
+      {showAISummary && (unreadCount > 0 || digest?.text) && (
+        <div style={{ marginTop: '12px', paddingTop: '10px', borderTop: '1px dashed rgba(128,128,128,0.35)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
+            <span style={{ fontSize: '0.75rem', opacity: 0.55, display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+              <Sparkles size={11} /> ai digest{digest?.date === todayKey() ? ' · today' : ''}
+            </span>
+            {!summarizing && unreadCount > 0 && (
+              <button
+                onClick={summarize}
+                disabled={!activeProvider}
+                title={activeProvider ? 'Regenerate AI summary' : 'Configure an AI provider in Settings → AI'}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  color: 'var(--accent-color)',
+                  fontSize: '0.75rem',
+                  cursor: activeProvider ? 'pointer' : 'not-allowed',
+                  opacity: activeProvider ? 0.8 : 0.4,
+                }}
+              >
+                {digest?.text ? 're-summarize' : 'summarize'}
+              </button>
+            )}
+          </div>
+          {summarizing && (
+            <span style={{ opacity: 0.7, display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '0.82rem' }}>
+              <RefreshCw size={11} /> summarizing…
+            </span>
+          )}
+          {!summarizing && digest?.text && (
+            <p style={{ margin: 0, whiteSpace: 'pre-wrap', opacity: 0.85, fontSize: '0.82rem' }}>{digest.text}</p>
+          )}
+          {digestError && (
+            <p style={{ margin: '4px 0 0', color: '#ff4444', fontSize: '0.78rem' }}>summary failed: {digestError}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function GmailDigest() {
   const [settings] = useSettings();
   const config = getConnectorConfig(settings, CONNECTOR_ID);
   const enabled = !!config.enabled;
+  const showAISummary = !!config.showAISummary;
 
   const { emails, unreadCount, isConnected, error } = useGmail(enabled);
 
@@ -50,6 +204,7 @@ export function GmailDigest() {
   const [wasConnected] = useState(() => localStorage.getItem('neko-gmail-connected') === 'true');
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const autoAttempted = useRef(false);
 
   const { loadProviders, completeText, activeProvider } = useAIProviders();
@@ -62,7 +217,12 @@ export function GmailDigest() {
   useEffect(() => {
     if (!open) return;
     const onDocClick = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+        const dropdown = document.querySelector('[data-gmail-dropdown]');
+        if (dropdown && !dropdown.contains(e.target as Node)) {
+          setOpen(false);
+        }
+      }
     };
     document.addEventListener('mousedown', onDocClick);
     return () => document.removeEventListener('mousedown', onDocClick);
@@ -112,6 +272,7 @@ export function GmailDigest() {
   return (
     <div ref={rootRef} style={{ position: 'relative', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto' }}>
       <button
+        ref={buttonRef}
         onClick={() => setOpen(o => !o)}
         style={{
           display: 'inline-flex',
@@ -148,105 +309,21 @@ export function GmailDigest() {
         <span style={{ marginLeft: '8px', color: '#ff4444', fontSize: '0.78rem' }}>{error}</span>
       )}
 
-      {open && (
-        <div
-          style={{
-            position: 'absolute',
-            top: '36px',
-            left: '50%',
-            transform: 'translateX(-50%)',
-            width: '520px',
-            maxWidth: '90vw',
-            maxHeight: '60vh',
-            overflowY: 'auto',
-            background: 'var(--bg-color, #111)',
-            border: '1px solid rgba(128,128,128,0.35)',
-            borderRadius: '6px',
-            padding: '14px 16px',
-            zIndex: 50,
-            textAlign: 'left',
-            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
-          }}
-        >
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
-            <span style={{ fontWeight: 500, fontSize: '0.85rem' }}>
-              inbox{unreadCount > 0 ? ` — ${unreadCount} unread` : ''}
-            </span>
-            <a
-              href={GMAIL_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{ color: 'var(--accent-color)', textDecoration: 'none', fontSize: '0.78rem', opacity: 0.85 }}
-            >
-              open gmail ↗
-            </a>
-          </div>
-
-          {emails.length > 0 ? (
-            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {emails.slice(0, 8).map((email) => (
-                <li key={email.id} style={{ lineHeight: 1.7 }}>
-                  <a
-                    href={GMAIL_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ display: 'flex', gap: '10px', color: 'var(--text-color)', textDecoration: 'none', opacity: 0.8 }}
-                    title={`${email.from}: ${email.subject}`}
-                  >
-                    <span style={{ opacity: 0.65, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '150px', flexShrink: 0 }}>
-                      {email.from}
-                    </span>
-                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {email.subject}
-                    </span>
-                  </a>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p style={{ margin: 0, opacity: 0.6, fontSize: '0.82rem' }}>inbox zero — nothing unread</p>
-          )}
-
-          {(unreadCount > 0 || digest?.text) && (
-            <div style={{ marginTop: '12px', paddingTop: '10px', borderTop: '1px dashed rgba(128,128,128,0.35)' }}>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
-                <span style={{ fontSize: '0.75rem', opacity: 0.55, display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
-                  <Sparkles size={11} /> ai digest{digest?.date === todayKey() ? ' · today' : ''}
-                </span>
-                {!summarizing && unreadCount > 0 && (
-                  <button
-                    onClick={summarize}
-                    disabled={!activeProvider}
-                    title={activeProvider ? 'Regenerate AI summary' : 'Configure an AI provider in Settings → AI'}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      color: 'var(--accent-color)',
-                      fontSize: '0.75rem',
-                      cursor: activeProvider ? 'pointer' : 'not-allowed',
-                      opacity: activeProvider ? 0.8 : 0.4,
-                    }}
-                  >
-                    {digest?.text ? 're-summarize' : 'summarize'}
-                  </button>
-                )}
-              </div>
-              {summarizing && (
-                <span style={{ opacity: 0.7, display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '0.82rem' }}>
-                  <RefreshCw size={11} /> summarizing…
-                </span>
-              )}
-              {!summarizing && digest?.text && (
-                <p style={{ margin: 0, whiteSpace: 'pre-wrap', opacity: 0.85, fontSize: '0.82rem' }}>{digest.text}</p>
-              )}
-              {!summarizing && !digest?.text && !digestError && activeProvider && unreadCount === 0 && null}
-              {digestError && (
-                <p style={{ margin: '4px 0 0', color: '#ff4444', fontSize: '0.78rem' }}>summary failed: {digestError}</p>
-              )}
-            </div>
-          )}
-        </div>
+      {open && buttonRef.current && (
+        createPortal(
+          <DropdownContent
+            emails={emails}
+            unreadCount={unreadCount}
+            digest={digest}
+            summarizing={summarizing}
+            digestError={digestError}
+            activeProvider={activeProvider}
+            summarize={summarize}
+            buttonRef={buttonRef}
+            showAISummary={showAISummary}
+          />,
+          document.body
+        )
       )}
     </div>
   );

--- a/src/connectors/gmail/GmailDigest.tsx
+++ b/src/connectors/gmail/GmailDigest.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Mail, Sparkles, RefreshCw } from 'lucide-react';
+import { Mail, Sparkles, RefreshCw, ChevronDown } from 'lucide-react';
 import { useGmail, type GmailEmail } from './useGmail';
 import { useSettings } from '../../hooks/useLocalStorage';
 import { getConnectorConfig } from '../types';
@@ -48,6 +48,8 @@ export function GmailDigest() {
   const [summarizing, setSummarizing] = useState(false);
   const [digestError, setDigestError] = useState<string | null>(null);
   const [wasConnected] = useState(() => localStorage.getItem('neko-gmail-connected') === 'true');
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
   const autoAttempted = useRef(false);
 
   const { loadProviders, completeText, activeProvider } = useAIProviders();
@@ -55,6 +57,16 @@ export function GmailDigest() {
   useEffect(() => {
     loadProviders();
   }, [loadProviders]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
 
   const summarize = useCallback(async () => {
     if (!activeProvider || summarizing || emails.length === 0) return;
@@ -95,99 +107,146 @@ export function GmailDigest() {
     return null;
   }
 
+  const latest = emails[0];
+
   return (
-    <div
-      className="gmail-digest-widget"
-      style={{
-        maxWidth: '560px',
-        margin: '0 auto',
-        padding: '12px 16px',
-        border: '1px solid var(--border-color, rgba(128,128,128,0.3))',
-        borderRadius: '6px',
-        fontSize: '0.85rem',
-      }}
-    >
-      <a
-        href={GMAIL_URL}
-        target="_blank"
-        rel="noopener noreferrer"
+    <div ref={rootRef} style={{ position: 'relative', height: '32px', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto' }}>
+      <button
+        onClick={() => setOpen(o => !o)}
         style={{
-          display: 'flex',
+          display: 'inline-flex',
           alignItems: 'center',
           gap: '8px',
+          fontSize: '0.85rem',
           color: 'var(--text-color)',
-          textDecoration: 'none',
-          opacity: 0.9,
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          padding: 0,
+          opacity: 0.8,
+          maxWidth: '480px',
         }}
+        onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
+        onMouseLeave={(e) => (e.currentTarget.style.opacity = '0.8')}
       >
         <Mail size={14} color="var(--accent-color)" />
         <span style={{ fontWeight: 500 }}>
           gmail{unreadCount > 0 ? ` — ${unreadCount} unread` : ' — inbox zero'}
         </span>
-      </a>
-
-      {emails.length > 0 && (
-        <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 0' }}>
-          {emails.slice(0, 5).map((email) => (
-            <li key={email.id} style={{ display: 'flex', gap: '8px', lineHeight: 1.6 }}>
-              <span style={{ opacity: 0.6, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '140px' }}>
-                {email.from}
-              </span>
-              <a
-                href={GMAIL_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: 'var(--text-color)', textDecoration: 'none', opacity: 0.75, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                title={email.subject}
-              >
-                {email.subject}
-              </a>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {(digest?.text || summarizing || digestError || unreadCount > 0) && (
-        <div style={{ marginTop: '10px', paddingTop: '10px', borderTop: '1px dashed var(--border-color, rgba(128,128,128,0.3))' }}>
-          {summarizing && (
-            <span style={{ opacity: 0.7, display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
-              <RefreshCw size={12} /> summarizing…
+        {latest && (
+          <>
+            <span style={{ opacity: 0.4 }}>•</span>
+            <span style={{ opacity: 0.7, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {latest.subject}
             </span>
-          )}
-          {!summarizing && digest?.text && (
-            <p style={{ margin: 0, whiteSpace: 'pre-wrap', opacity: 0.85 }}>{digest.text}</p>
-          )}
-          {digestError && (
-            <p style={{ margin: 0, color: '#ff4444', fontSize: '0.8rem' }}>summary failed: {digestError}</p>
-          )}
-          {!summarizing && unreadCount > 0 && (
-            <button
-              onClick={summarize}
-              disabled={!activeProvider}
-              title={activeProvider ? 'Regenerate AI summary' : 'Configure an AI provider in Settings → AI'}
-              style={{
-                marginTop: '6px',
-                background: 'none',
-                border: 'none',
-                padding: 0,
-                color: 'var(--accent-color)',
-                fontSize: '0.8rem',
-                cursor: activeProvider ? 'pointer' : 'not-allowed',
-                opacity: activeProvider ? 0.8 : 0.4,
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '4px',
-              }}
-            >
-              <Sparkles size={12} />
-              {digest?.text ? 're-summarize' : 'ai summary'}
-            </button>
-          )}
-        </div>
-      )}
+          </>
+        )}
+        <ChevronDown size={12} style={{ transform: open ? 'rotate(180deg)' : undefined, transition: 'transform 150ms' }} />
+      </button>
 
       {error && (
-        <p style={{ margin: '8px 0 0', color: '#ff4444', fontSize: '0.8rem' }}>gmail: {error}</p>
+        <span style={{ marginLeft: '8px', color: '#ff4444', fontSize: '0.78rem' }}>{error}</span>
+      )}
+
+      {open && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '36px',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: '520px',
+            maxWidth: '90vw',
+            maxHeight: '60vh',
+            overflowY: 'auto',
+            background: 'var(--bg-color, #111)',
+            border: '1px solid rgba(128,128,128,0.35)',
+            borderRadius: '6px',
+            padding: '14px 16px',
+            zIndex: 50,
+            textAlign: 'left',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.35)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '8px' }}>
+            <span style={{ fontWeight: 500, fontSize: '0.85rem' }}>
+              inbox{unreadCount > 0 ? ` — ${unreadCount} unread` : ''}
+            </span>
+            <a
+              href={GMAIL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'var(--accent-color)', textDecoration: 'none', fontSize: '0.78rem', opacity: 0.85 }}
+            >
+              open gmail ↗
+            </a>
+          </div>
+
+          {emails.length > 0 ? (
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+              {emails.slice(0, 8).map((email) => (
+                <li key={email.id} style={{ lineHeight: 1.7 }}>
+                  <a
+                    href={GMAIL_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ display: 'flex', gap: '10px', color: 'var(--text-color)', textDecoration: 'none', opacity: 0.8 }}
+                    title={`${email.from}: ${email.subject}`}
+                  >
+                    <span style={{ opacity: 0.65, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '150px', flexShrink: 0 }}>
+                      {email.from}
+                    </span>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {email.subject}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p style={{ margin: 0, opacity: 0.6, fontSize: '0.82rem' }}>inbox zero — nothing unread</p>
+          )}
+
+          {(unreadCount > 0 || digest?.text) && (
+            <div style={{ marginTop: '12px', paddingTop: '10px', borderTop: '1px dashed rgba(128,128,128,0.35)' }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '4px' }}>
+                <span style={{ fontSize: '0.75rem', opacity: 0.55, display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
+                  <Sparkles size={11} /> ai digest{digest?.date === todayKey() ? ' · today' : ''}
+                </span>
+                {!summarizing && unreadCount > 0 && (
+                  <button
+                    onClick={summarize}
+                    disabled={!activeProvider}
+                    title={activeProvider ? 'Regenerate AI summary' : 'Configure an AI provider in Settings → AI'}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      color: 'var(--accent-color)',
+                      fontSize: '0.75rem',
+                      cursor: activeProvider ? 'pointer' : 'not-allowed',
+                      opacity: activeProvider ? 0.8 : 0.4,
+                    }}
+                  >
+                    {digest?.text ? 're-summarize' : 'summarize'}
+                  </button>
+                )}
+              </div>
+              {summarizing && (
+                <span style={{ opacity: 0.7, display: 'inline-flex', alignItems: 'center', gap: '6px', fontSize: '0.82rem' }}>
+                  <RefreshCw size={11} /> summarizing…
+                </span>
+              )}
+              {!summarizing && digest?.text && (
+                <p style={{ margin: 0, whiteSpace: 'pre-wrap', opacity: 0.85, fontSize: '0.82rem' }}>{digest.text}</p>
+              )}
+              {!summarizing && !digest?.text && !digestError && activeProvider && unreadCount === 0 && null}
+              {digestError && (
+                <p style={{ margin: '4px 0 0', color: '#ff4444', fontSize: '0.78rem' }}>summary failed: {digestError}</p>
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/connectors/gmail/index.ts
+++ b/src/connectors/gmail/index.ts
@@ -9,6 +9,7 @@ export const gmailConnector: Connector = {
   placement: 'center-widget',
   defaultConfig: {
     enabled: false,
+    showAISummary: true,
   },
   Widget: GmailDigest,
   SettingsWidget: GmailSettings,

--- a/src/connectors/gmail/index.ts
+++ b/src/connectors/gmail/index.ts
@@ -1,0 +1,17 @@
+import type { Connector } from '../types'
+import { GmailDigest } from './GmailDigest'
+import { GmailSettings } from './settings'
+
+export const gmailConnector: Connector = {
+  id: 'gmail',
+  name: 'Gmail',
+  description: 'See your unread email count and get an AI-powered inbox summary',
+  placement: 'center-widget',
+  defaultConfig: {
+    enabled: false,
+  },
+  Widget: GmailDigest,
+  SettingsWidget: GmailSettings,
+  oauth2Scopes: ['https://www.googleapis.com/auth/gmail.readonly'],
+  manifestPermissions: ['identity'],
+}

--- a/src/connectors/gmail/settings.tsx
+++ b/src/connectors/gmail/settings.tsx
@@ -9,6 +9,7 @@ interface GmailSettingsProps {
 export function GmailSettings({ config, onConfigChange }: GmailSettingsProps) {
   const { isConnected, connect, disconnect, error } = useGmail(false);
   const enabled = !!config.enabled;
+  const showAISummary = !!config.showAISummary;
   const isExt = isIdentityAvailable();
 
   return (
@@ -33,6 +34,20 @@ export function GmailSettings({ config, onConfigChange }: GmailSettingsProps) {
             <div className="saas-toggle-thumb" />
           </button>
         </div>
+
+        {enabled && (
+          <div className="saas-toggle-row">
+            <span className="saas-toggle-label">Only show AI summary</span>
+            <button
+              className={`saas-toggle-btn ${showAISummary ? 'active' : ''}`}
+              onClick={() => onConfigChange({ showAISummary: !showAISummary })}
+              disabled={!isConnected}
+              style={{ opacity: !isConnected ? 0.5 : 1, cursor: !isConnected ? 'not-allowed' : 'pointer' }}
+            >
+              <div className="saas-toggle-thumb" />
+            </button>
+          </div>
+        )}
       </div>
 
       {!isConnected ? (

--- a/src/connectors/gmail/settings.tsx
+++ b/src/connectors/gmail/settings.tsx
@@ -1,0 +1,61 @@
+import { useGmail } from './useGmail';
+import { isIdentityAvailable } from '../../utils/browser';
+
+interface GmailSettingsProps {
+  config: Record<string, unknown>
+  onConfigChange: (patch: Record<string, unknown>) => void
+}
+
+export function GmailSettings({ config, onConfigChange }: GmailSettingsProps) {
+  const { isConnected, connect, disconnect, error } = useGmail(false);
+  const enabled = !!config.enabled;
+  const isExt = isIdentityAvailable();
+
+  return (
+    <div className='saas-card'>
+      <label className='saas-label'>Gmail</label>
+
+      {!isExt && (
+        <div className='saas-hint' style={{ color: '#ffb300', marginBottom: 16, border: '1px solid rgba(255, 179, 0, 0.2)', padding: '8px', borderRadius: '4px' }}>
+          Identity API not detected. Please make sure this is running as a loaded extension in Chrome or Firefox.
+        </div>
+      )}
+
+      <div className='saas-toggle-list' style={{ marginBottom: 12 }}>
+        <div className="saas-toggle-row">
+          <span className="saas-toggle-label">Show inbox digest on home page</span>
+          <button
+            className={`saas-toggle-btn ${enabled ? 'active' : ''}`}
+            onClick={() => onConfigChange({ enabled: !enabled })}
+            disabled={!isConnected}
+            style={{ opacity: !isConnected ? 0.5 : 1, cursor: !isConnected ? 'not-allowed' : 'pointer' }}
+          >
+            <div className="saas-toggle-thumb" />
+          </button>
+        </div>
+      </div>
+
+      {!isConnected ? (
+        <div>
+          <p className='saas-hint' style={{ marginBottom: 12 }}>
+            Connect your Google account to see unread email and an AI-powered summary. Google will ask for read-only Gmail access on first connect.
+          </p>
+          <button className='saas-btn-primary' onClick={connect}>
+            Connect Gmail
+          </button>
+        </div>
+      ) : (
+        <div>
+          <p className='saas-hint' style={{ marginBottom: 12, color: 'var(--accent-color)' }}>✓ Connected to Gmail</p>
+          <button className='saas-btn-secondary' onClick={disconnect}>
+            Disconnect
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <p className='saas-hint' style={{ marginTop: 12, color: '#ff4444' }}>Error: {error}</p>
+      )}
+    </div>
+  );
+}

--- a/src/connectors/gmail/useGmail.ts
+++ b/src/connectors/gmail/useGmail.ts
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback } from 'react';
+import { STORAGE_KEYS } from '../../hooks/useLocalStorage';
+import { getAuthToken, removeCachedAuthToken } from '../../utils/browser';
+
+export interface GmailEmail {
+  id: string;
+  subject: string;
+  from: string;
+  snippet: string;
+}
+
+interface GmailCache {
+  emails: GmailEmail[];
+  unreadCount: number;
+}
+
+const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+function readCache(): GmailCache {
+  try {
+    const cached = localStorage.getItem(STORAGE_KEYS.GMAIL_LAST_EMAILS);
+    if (cached) return JSON.parse(cached);
+  } catch { /* ignore corrupt cache */ }
+  return { emails: [], unreadCount: 0 };
+}
+
+function header(msg: any, name: string): string {
+  const found = msg?.payload?.headers?.find(
+    (h: any) => h.name.toLowerCase() === name.toLowerCase()
+  );
+  return found?.value ?? '';
+}
+
+function shortFrom(from: string): string {
+  const match = from.match(/"?([^"<]*)"?\s*<(.+)>/);
+  const name = match ? (match[1] || match[2]) : from;
+  return name.trim();
+}
+
+async function fetchUnread(token: string): Promise<GmailCache> {
+  // Unread count via resultSizeEstimate
+  const countUrl = `${GMAIL_API}/messages?q=${encodeURIComponent('is:unread')}&maxResults=1`;
+  const countRes = await fetch(countUrl, { headers: { Authorization: `Bearer ${token}` } });
+  if (!countRes.ok) throw new Error(`Gmail API error: ${countRes.status}`);
+  const countData = await countRes.json();
+  const unreadCount = countData.resultSizeEstimate ?? 0;
+
+  if (unreadCount === 0) return { emails: [], unreadCount: 0 };
+
+  // Latest unread emails with metadata
+  const listUrl = `${GMAIL_API}/messages?q=${encodeURIComponent('is:unread')}&maxResults=8`;
+  const listRes = await fetch(listUrl, { headers: { Authorization: `Bearer ${token}` } });
+  if (!listRes.ok) throw new Error(`Gmail API error: ${listRes.status}`);
+  const listData = await listRes.json();
+  const ids: { id: string }[] = listData.messages ?? [];
+
+  const emails = await Promise.all(
+    ids.map(async ({ id }) => {
+      const msgUrl = `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From`;
+      const msgRes = await fetch(msgUrl, { headers: { Authorization: `Bearer ${token}` } });
+      if (!msgRes.ok) throw new Error(`Gmail API error: ${msgRes.status}`);
+      const msg = await msgRes.json();
+      return {
+        id,
+        subject: header(msg, 'Subject') || '(no subject)',
+        from: shortFrom(header(msg, 'From')),
+        snippet: msg.snippet ?? '',
+      };
+    })
+  );
+
+  return { emails, unreadCount };
+}
+
+export function useGmail(fetchEnabled: boolean) {
+  const [token, setToken] = useState<string | null>(null);
+  const [cache, setCache] = useState<GmailCache>(readCache);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    getAuthToken(false).then((authToken) => {
+      if (!isMounted) return;
+      if (authToken) {
+        setToken(authToken);
+        localStorage.setItem(STORAGE_KEYS.GMAIL_CONNECTED, 'true');
+      }
+    });
+    return () => { isMounted = false; };
+  }, []);
+
+  const connect = useCallback(() => {
+    getAuthToken(true).then((authToken) => {
+      if (authToken) {
+        setToken(authToken);
+        localStorage.setItem(STORAGE_KEYS.GMAIL_CONNECTED, 'true');
+        setError(null);
+      } else {
+        setError('Auth failed');
+      }
+    });
+  }, []);
+
+  const disconnect = useCallback(() => {
+    if (!token) return;
+    removeCachedAuthToken(token).then(() => {
+      setToken(null);
+      setCache({ emails: [], unreadCount: 0 });
+      localStorage.setItem(STORAGE_KEYS.GMAIL_CONNECTED, 'false');
+      localStorage.removeItem(STORAGE_KEYS.GMAIL_LAST_EMAILS);
+    });
+  }, [token]);
+
+  useEffect(() => {
+    if (!fetchEnabled || !token) return;
+
+    let isMounted = true;
+    let timeoutId: number;
+
+    const refresh = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const next = await fetchUnread(token);
+        if (!isMounted) return;
+        setCache(next);
+        localStorage.setItem(STORAGE_KEYS.GMAIL_LAST_EMAILS, JSON.stringify(next));
+      } catch (err: any) {
+        if (!isMounted) return;
+        if (err.message?.includes('401')) {
+          // Token expired — clear cache and re-auth interactively on next connect
+          removeCachedAuthToken(token).then(() => {
+            if (!isMounted) return;
+            setToken(null);
+          });
+        }
+        setError(err.message);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+
+      if (isMounted) {
+        timeoutId = window.setTimeout(refresh, 5 * 60 * 1000);
+      }
+    };
+
+    refresh();
+
+    return () => {
+      isMounted = false;
+      if (timeoutId) window.clearTimeout(timeoutId);
+    };
+  }, [token, fetchEnabled]);
+
+  return {
+    token,
+    isConnected: !!token,
+    connect,
+    disconnect,
+    emails: cache.emails,
+    unreadCount: cache.unreadCount,
+    loading,
+    error,
+  };
+}

--- a/src/connectors/gmail/useGmail.ts
+++ b/src/connectors/gmail/useGmail.ts
@@ -37,11 +37,20 @@ function shortFrom(from: string): string {
   return name.trim();
 }
 
+async function apiError(res: Response): Promise<string> {
+  let detail = '';
+  try {
+    const data = await res.json();
+    detail = data?.error?.message ? ` — ${data.error.message}` : '';
+  } catch { /* non-JSON body */ }
+  return `Gmail API error: ${res.status}${detail}`;
+}
+
 async function fetchUnread(token: string): Promise<GmailCache> {
   // Unread count via resultSizeEstimate
   const countUrl = `${GMAIL_API}/messages?q=${encodeURIComponent('is:unread')}&maxResults=1`;
   const countRes = await fetch(countUrl, { headers: { Authorization: `Bearer ${token}` } });
-  if (!countRes.ok) throw new Error(`Gmail API error: ${countRes.status}`);
+  if (!countRes.ok) throw new Error(await apiError(countRes));
   const countData = await countRes.json();
   const unreadCount = countData.resultSizeEstimate ?? 0;
 
@@ -50,7 +59,7 @@ async function fetchUnread(token: string): Promise<GmailCache> {
   // Latest unread emails with metadata
   const listUrl = `${GMAIL_API}/messages?q=${encodeURIComponent('is:unread')}&maxResults=8`;
   const listRes = await fetch(listUrl, { headers: { Authorization: `Bearer ${token}` } });
-  if (!listRes.ok) throw new Error(`Gmail API error: ${listRes.status}`);
+  if (!listRes.ok) throw new Error(await apiError(listRes));
   const listData = await listRes.json();
   const ids: { id: string }[] = listData.messages ?? [];
 
@@ -58,7 +67,7 @@ async function fetchUnread(token: string): Promise<GmailCache> {
     ids.map(async ({ id }) => {
       const msgUrl = `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From`;
       const msgRes = await fetch(msgUrl, { headers: { Authorization: `Bearer ${token}` } });
-      if (!msgRes.ok) throw new Error(`Gmail API error: ${msgRes.status}`);
+      if (!msgRes.ok) throw new Error(await apiError(msgRes));
       const msg = await msgRes.json();
       return {
         id,
@@ -128,8 +137,9 @@ export function useGmail(fetchEnabled: boolean) {
         localStorage.setItem(STORAGE_KEYS.GMAIL_LAST_EMAILS, JSON.stringify(next));
       } catch (err: any) {
         if (!isMounted) return;
-        if (err.message?.includes('401')) {
-          // Token expired — clear cache and re-auth interactively on next connect
+        // 401 = expired token, 403 = token lacks the Gmail scope (e.g. cached
+        // from before the scope was added). Both need a fresh interactive grant.
+        if (err.message?.includes('401') || err.message?.includes('403')) {
           removeCachedAuthToken(token).then(() => {
             if (!isMounted) return;
             setToken(null);

--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -2,10 +2,12 @@ import type { ComponentType } from 'react'
 import type { Connector } from './types'
 import { updateConnectorConfig } from './types'
 import { googleCalendarConnector } from './google-calendar'
+import { gmailConnector } from './gmail'
 export { updateConnectorConfig }
 
 const connectors: Connector[] = [
   googleCalendarConnector,
+  gmailConnector,
 ]
 
 interface ConnectorWithWidget extends Connector {

--- a/src/hooks/useAIProviders.ts
+++ b/src/hooks/useAIProviders.ts
@@ -77,10 +77,7 @@ export function useAIProviders() {
     }
   }, [])
 
-  const executeCommand = useCallback(async (
-    prompt: string,
-    context: { aliases: string; bookmarks: string; tabs: string; history: string; memories: string; browsingHistory?: string }
-  ): Promise<AIAction[]> => {
+  const callModel = useCallback(async (prompt: string): Promise<string> => {
     const currentActive = activeProvider
     if (!currentActive) {
       throw new Error('No active AI provider configured')
@@ -95,6 +92,70 @@ export function useAIProviders() {
     const baseUrl = providerConfig.baseUrl || defaults.baseUrl
     const model = providerConfig.model && providerConfig.model !== 'gemini-1.5-flash' ? providerConfig.model : defaults.model
 
+    let response: Response
+
+    if (currentActive === 'gemini') {
+      response = await fetch(`${baseUrl}/models/${model}:generateContent`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': providerConfig.apiKey,
+        },
+        body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }),
+      })
+    } else if (currentActive === 'openai' || currentActive === 'custom') {
+      response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${providerConfig.apiKey}`,
+        },
+        body: JSON.stringify({
+          model,
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0.3,
+        }),
+      })
+    } else if (currentActive === 'anthropic') {
+      response = await fetch(`${baseUrl}/messages`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': providerConfig.apiKey,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model,
+          max_tokens: 1024,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      })
+    } else {
+      throw new Error(`Unknown provider: ${currentActive}`)
+    }
+
+    if (!response.ok) {
+      const error = await response.text()
+      throw new Error(`AI API error: ${response.status} — ${error}`)
+    }
+
+    const data = await response.json()
+
+    if (currentActive === 'openai' || currentActive === 'custom') {
+      return data.choices?.[0]?.message?.content || ''
+    } else if (currentActive === 'anthropic') {
+      return data.content?.[0]?.text || ''
+    } else if (currentActive === 'gemini') {
+      return data.candidates?.[0]?.content?.parts?.[0]?.text || ''
+    }
+
+    return ''
+  }, [activeProvider, providers])
+
+  const executeCommand = useCallback(async (
+    prompt: string,
+    context: { aliases: string; bookmarks: string; tabs: string; history: string; memories: string; browsingHistory?: string }
+  ): Promise<AIAction[]> => {
     const safeQuery = sanitize(prompt)
 
     const hasBrowsingHistory = context.browsingHistory && context.browsingHistory.length > 0
@@ -145,63 +206,7 @@ When using "save-to-journal": include a "date" field matching the date being sum
 
 Respond ONLY with a valid JSON array. No markdown, no explanation.`
 
-    let response: Response
-
-    if (currentActive === 'gemini') {
-      response = await fetch(`${baseUrl}/models/${model}:generateContent`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-goog-api-key': providerConfig.apiKey,
-        },
-        body: JSON.stringify({ contents: [{ parts: [{ text: systemPrompt }] }] }),
-      })
-    } else if (currentActive === 'openai' || currentActive === 'custom') {
-      response = await fetch(`${baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${providerConfig.apiKey}`,
-        },
-        body: JSON.stringify({
-          model,
-          messages: [{ role: 'user', content: systemPrompt }],
-          temperature: 0.3,
-        }),
-      })
-    } else if (currentActive === 'anthropic') {
-      response = await fetch(`${baseUrl}/messages`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': providerConfig.apiKey,
-          'anthropic-version': '2023-06-01',
-        },
-        body: JSON.stringify({
-          model,
-          max_tokens: 1024,
-          messages: [{ role: 'user', content: systemPrompt }],
-        }),
-      })
-    } else {
-      throw new Error(`Unknown provider: ${currentActive}`)
-    }
-
-    if (!response.ok) {
-      const error = await response.text()
-      throw new Error(`AI API error: ${response.status} — ${error}`)
-    }
-
-    const data = await response.json()
-    let content = ''
-
-    if (currentActive === 'openai' || currentActive === 'custom') {
-      content = data.choices?.[0]?.message?.content || ''
-    } else if (currentActive === 'anthropic') {
-      content = data.content?.[0]?.text || ''
-    } else if (currentActive === 'gemini') {
-      content = data.candidates?.[0]?.content?.parts?.[0]?.text || ''
-    }
+    const content = await callModel(systemPrompt)
 
     const jsonMatch = content.match(/\[[\s\S]*\]/)
     if (!jsonMatch) {
@@ -214,7 +219,11 @@ Respond ONLY with a valid JSON array. No markdown, no explanation.`
     }
     const actions = parsed as AIAction[]
     return actions
-  }, [activeProvider, providers])
+  }, [activeProvider, providers, callModel])
+
+  const completeText = useCallback(async (prompt: string): Promise<string> => {
+    return callModel(prompt)
+  }, [callModel])
 
   return {
     providers,
@@ -224,6 +233,7 @@ Respond ONLY with a valid JSON array. No markdown, no explanation.`
     removeProvider,
     setActive,
     executeCommand,
+    completeText,
     providerDefaults: PROVIDER_DEFAULTS,
   }
 }

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -8,6 +8,9 @@ export const STORAGE_KEYS = {
   BG_IMAGE: 'neko-bg-image',
   CALENDAR_CONNECTED: 'neko-calendar-connected',
   CALENDAR_LAST_EVENT: 'neko-calendar-last-event',
+  GMAIL_CONNECTED: 'neko-gmail-connected',
+  GMAIL_LAST_EMAILS: 'neko-gmail-last-emails',
+  GMAIL_DIGEST: 'neko-gmail-digest',
 } as const;
 
 const DEFAULT_CATEGORIES: BookmarkCategory[] = [

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -149,7 +149,7 @@
   width: 100%;
   max-width: 520px;
   padding: 10px 16px;
-  background: transparent;
+  background: rgba(127, 127, 127, 0.08);
   border: 1px solid var(--border, #353A3E);
   border-radius: 6px;
   cursor: pointer;
@@ -164,7 +164,7 @@
 
 .cp-trigger-icon {
   color: var(--text-secondary);
-  opacity: 0.45;
+  opacity: 0.7;
   flex-shrink: 0;
 }
 
@@ -173,7 +173,7 @@
   font-size: 13px;
   font-family: var(--font-mono), monospace;
   color: var(--text-secondary);
-  opacity: 0.35;
+  opacity: 0.6;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
@@ -190,7 +190,7 @@
   font-family: var(--font-mono), monospace;
   font-size: 10px;
   color: var(--text-secondary);
-  opacity: 0.4;
+  opacity: 0.65;
   border: 1px solid var(--border, #353A3E);
   border-radius: 3px;
   padding: 2px 5px;
@@ -200,7 +200,7 @@
 .cp-trigger-sep {
   font-size: 10px;
   color: var(--text-secondary);
-  opacity: 0.25;
+  opacity: 0.4;
 }
 
 /* engine switcher */
@@ -287,8 +287,8 @@
 
 /* glass mode — trigger bar */
 .has-bg .cp-trigger {
-  background: transparent;
-  border-color: rgba(255,255,255,0.12);
+  background: rgba(0, 0, 0, 0.25);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .has-bg .cp-trigger:hover {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -80,20 +80,7 @@ function getRedirectUri(): string {
   return 'https://localhost/'
 }
 
-export function getAuthToken(interactive: boolean): Promise<string | null> {
-  if (typeof chrome !== 'undefined' && chrome.identity?.getAuthToken) {
-    return new Promise((resolve) => {
-      chrome.identity.getAuthToken({ interactive }, (result) => {
-        if (chrome?.runtime?.lastError) {
-          resolve(null)
-          return
-        }
-        const token = result as unknown as string | undefined
-        resolve(token ?? null)
-      })
-    })
-  }
-
+function launchWebAuthFlow(interactive: boolean): Promise<string | null> {
   if (typeof browser !== 'undefined' && browser?.identity?.launchWebAuthFlow) {
     const clientId = getGoogleClientId()
     if (!clientId) return Promise.resolve(null)
@@ -126,6 +113,24 @@ export function getAuthToken(interactive: boolean): Promise<string | null> {
   }
 
   return Promise.resolve(null)
+}
+
+export function getAuthToken(interactive: boolean): Promise<string | null> {
+  if (typeof chrome !== 'undefined' && chrome.identity?.getAuthToken) {
+    return new Promise((resolve) => {
+      chrome.identity.getAuthToken({ interactive }, (result) => {
+        if (!chrome?.runtime?.lastError && result) {
+          resolve(result as unknown as string)
+          return
+        }
+        // Some Chromium browsers (e.g. Brave) can fail getAuthToken while
+        // launchWebAuthFlow works — fall back before giving up.
+        launchWebAuthFlow(interactive).then(resolve)
+      })
+    })
+  }
+
+  return launchWebAuthFlow(interactive)
 }
 
 export function removeCachedAuthToken(token: string): Promise<void> {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,8 @@ export default defineConfig(({ mode }) => {
     define: {
       __GOOGLE_CLIENT_ID__: JSON.stringify(env.GOOGLE_CLIENT_ID || ''),
       __GOOGLE_CLIENT_SCOPES__: JSON.stringify(
-        env.GOOGLE_CLIENT_SCOPES || 'https://www.googleapis.com/auth/calendar.events.readonly'
+        env.GOOGLE_CLIENT_SCOPES ||
+          'https://www.googleapis.com/auth/calendar.events.readonly,https://www.googleapis.com/auth/gmail.readonly'
       ),
     },
     plugins: [


### PR DESCRIPTION
## What changed
- **Gmail connector**: compact widget row + dropdown panel, AI inbox digest improvements, settings additions (showAISummary config)
- **Search trigger bar visibility**: filled background, higher contrast icon/placeholder/kbd hints; glass-mode dark scrim over background images
- **README**: document Gmail integration (features, settings, install note, permissions)

## Side effects / watch out
- Gmail scope is read-only (`gmail.readonly`); `identity` permission still conditional at build time
- Search bar styling change affects both default and glass (background image) modes

Closes the gmail connector feature work on this branch.